### PR TITLE
Harden audio pipeline against silent data loss and malformed input

### DIFF
--- a/src/audio/decode/pcm.rs
+++ b/src/audio/decode/pcm.rs
@@ -39,9 +39,26 @@ impl PcmDecoder {
 
 impl Decoder for PcmDecoder {
     fn decode(&self, data: &[u8]) -> Result<Arc<[Sample]>, Error> {
+        let bytes_per_sample: usize = match self.bit_depth {
+            16 => 2,
+            24 => 3,
+            other => return Err(Error::Protocol(format!("Unsupported bit depth: {}", other))),
+        };
+
+        if data.is_empty() {
+            return Err(Error::Protocol("Empty PCM data".to_string()));
+        }
+        if !data.len().is_multiple_of(bytes_per_sample) {
+            return Err(Error::Protocol(format!(
+                "Truncated {}-bit PCM: {} bytes is not a multiple of {}",
+                self.bit_depth,
+                data.len(),
+                bytes_per_sample,
+            )));
+        }
+
         match (self.bit_depth, self.endian) {
             (16, PcmEndian::Little) => {
-                // Convert 16-bit little-endian PCM to Sample
                 let samples: Vec<Sample> = data
                     .chunks_exact(2)
                     .map(|c| {
@@ -52,7 +69,6 @@ impl Decoder for PcmDecoder {
                 Ok(Arc::from(samples.into_boxed_slice()))
             }
             (16, PcmEndian::Big) => {
-                // Convert 16-bit big-endian PCM to Sample
                 let samples: Vec<Sample> = data
                     .chunks_exact(2)
                     .map(|c| {
@@ -63,7 +79,6 @@ impl Decoder for PcmDecoder {
                 Ok(Arc::from(samples.into_boxed_slice()))
             }
             (24, PcmEndian::Little) => {
-                // Convert 24-bit little-endian PCM to Sample
                 let samples: Vec<Sample> = data
                     .chunks_exact(3)
                     .map(|c| Sample::from_i24_le([c[0], c[1], c[2]]))
@@ -71,17 +86,14 @@ impl Decoder for PcmDecoder {
                 Ok(Arc::from(samples.into_boxed_slice()))
             }
             (24, PcmEndian::Big) => {
-                // Convert 24-bit big-endian PCM to Sample
                 let samples: Vec<Sample> = data
                     .chunks_exact(3)
                     .map(|c| Sample::from_i24_be([c[0], c[1], c[2]]))
                     .collect();
                 Ok(Arc::from(samples.into_boxed_slice()))
             }
-            _ => Err(Error::Protocol(format!(
-                "Unsupported bit depth: {}",
-                self.bit_depth
-            ))),
+            // Unreachable: bit_depth validated above
+            _ => unreachable!(),
         }
     }
 }

--- a/src/audio/types.rs
+++ b/src/audio/types.rs
@@ -109,7 +109,10 @@ impl AudioFormat {
         debug_assert!(self.channels > 0, "AudioFormat with 0 channels");
         debug_assert!(self.sample_rate > 0, "AudioFormat with 0 sample_rate");
         let frames = num_samples / self.channels.max(1) as usize;
-        (frames as i64 * 1_000_000) / self.sample_rate.max(1) as i64
+        let rate = self.sample_rate.max(1) as i64;
+        // Round to nearest instead of truncating so that duration_us stays
+        // consistent with the remainder-tracking in advance_cursor().
+        (frames as i64 * 1_000_000 + rate / 2) / rate
     }
 }
 

--- a/src/protocol/client.rs
+++ b/src/protocol/client.rs
@@ -611,6 +611,11 @@ impl ProtocolClient {
         message_tx: UnboundedSender<Message>,
         clock_sync: Arc<Mutex<ClockSync>>,
     ) {
+        let mut audio_closed = false;
+        let mut artwork_closed = false;
+        let mut visualizer_closed = false;
+        let mut message_closed = false;
+
         while let Some(msg) = read.next().await {
             match msg {
                 Ok(WsMessage::Binary(data)) => {
@@ -622,7 +627,12 @@ impl ProtocolClient {
                                 chunk.timestamp,
                                 chunk.data.len()
                             );
-                            let _ = audio_tx.send(chunk);
+                            if !audio_closed && audio_tx.send(chunk).is_err() {
+                                log::error!(
+                                    "Audio receiver dropped — audio data will be discarded"
+                                );
+                                audio_closed = true;
+                            }
                         }
                         Ok(BinaryFrame::Artwork(chunk)) => {
                             log::debug!(
@@ -631,7 +641,12 @@ impl ProtocolClient {
                                 chunk.timestamp,
                                 chunk.data.len()
                             );
-                            let _ = artwork_tx.send(chunk);
+                            if !artwork_closed && artwork_tx.send(chunk).is_err() {
+                                log::error!(
+                                    "Artwork receiver dropped — artwork data will be discarded"
+                                );
+                                artwork_closed = true;
+                            }
                         }
                         Ok(BinaryFrame::Visualizer(chunk)) => {
                             log::debug!(
@@ -639,7 +654,10 @@ impl ProtocolClient {
                                 chunk.timestamp,
                                 chunk.data.len()
                             );
-                            let _ = visualizer_tx.send(chunk);
+                            if !visualizer_closed && visualizer_tx.send(chunk).is_err() {
+                                log::error!("Visualizer receiver dropped — visualizer data will be discarded");
+                                visualizer_closed = true;
+                            }
                         }
                         Ok(BinaryFrame::Unknown { type_id, .. }) => {
                             log::warn!("Received unknown binary type: {}", type_id);
@@ -678,8 +696,11 @@ impl ProtocolClient {
                                         );
                                     }
                                 }
-                            } else {
-                                let _ = message_tx.send(msg);
+                            } else if !message_closed && message_tx.send(msg).is_err() {
+                                log::error!(
+                                    "Message receiver dropped — messages will be discarded"
+                                );
+                                message_closed = true;
                             }
                         }
                         Err(e) => {

--- a/tests/pcm_decoder.rs
+++ b/tests/pcm_decoder.rs
@@ -42,36 +42,31 @@ fn test_decode_pcm_24bit() {
 #[test]
 fn test_decode_pcm_16bit_empty_input() {
     let decoder = PcmDecoder::new(16);
-    let samples = decoder.decode(&[]).unwrap();
-    assert_eq!(samples.len(), 0);
+    let result = decoder.decode(&[]);
+    assert!(result.is_err(), "empty input should be rejected");
 }
 
 #[test]
 fn test_decode_pcm_24bit_empty_input() {
     let decoder = PcmDecoder::new(24);
-    let samples = decoder.decode(&[]).unwrap();
-    assert_eq!(samples.len(), 0);
+    let result = decoder.decode(&[]);
+    assert!(result.is_err(), "empty input should be rejected");
 }
 
 #[test]
-fn test_decode_pcm_16bit_misaligned_trailing_byte_dropped() {
+fn test_decode_pcm_16bit_misaligned_trailing_byte_rejected() {
     let decoder = PcmDecoder::new(16);
-    // 3 bytes: one complete 16-bit sample + 1 trailing byte
-    let data = vec![0x00, 0x04, 0xFF];
-    let samples = decoder.decode(&data).unwrap();
-    // chunks_exact(2) silently drops the trailing byte
-    assert_eq!(samples.len(), 1);
-    assert_eq!(samples[0].to_i16(), 1024);
+    // 3 bytes: not a multiple of 2
+    let result = decoder.decode(&[0x00, 0x04, 0xFF]);
+    assert!(result.is_err(), "truncated 16-bit PCM should be rejected");
 }
 
 #[test]
-fn test_decode_pcm_24bit_misaligned_trailing_bytes_dropped() {
+fn test_decode_pcm_24bit_misaligned_trailing_bytes_rejected() {
     let decoder = PcmDecoder::new(24);
-    // 5 bytes: one complete 24-bit sample + 2 trailing bytes
-    let data = vec![0x00, 0x10, 0x00, 0xAB, 0xCD];
-    let samples = decoder.decode(&data).unwrap();
-    assert_eq!(samples.len(), 1);
-    assert_eq!(samples[0], Sample(4096));
+    // 5 bytes: not a multiple of 3
+    let result = decoder.decode(&[0x00, 0x10, 0x00, 0xAB, 0xCD]);
+    assert!(result.is_err(), "truncated 24-bit PCM should be rejected");
 }
 
 #[test]
@@ -135,14 +130,20 @@ fn test_decode_pcm_32bit_unsupported() {
 fn test_decode_pcm_16bit_sub_sample_input() {
     let decoder = PcmDecoder::new(16);
     // Single byte — not enough for one 16-bit sample
-    let samples = decoder.decode(&[0xFF]).unwrap();
-    assert_eq!(samples.len(), 0);
+    let result = decoder.decode(&[0xFF]);
+    assert!(
+        result.is_err(),
+        "sub-sample 16-bit input should be rejected"
+    );
 }
 
 #[test]
 fn test_decode_pcm_24bit_sub_sample_input() {
     let decoder = PcmDecoder::new(24);
     // Two bytes — not enough for one 24-bit sample
-    let samples = decoder.decode(&[0xFF, 0xFF]).unwrap();
-    assert_eq!(samples.len(), 0);
+    let result = decoder.decode(&[0xFF, 0xFF]);
+    assert!(
+        result.is_err(),
+        "sub-sample 24-bit input should be rejected"
+    );
 }


### PR DESCRIPTION
Three fixes from a code quality audit as I'm trying to think of what could be causing some audio distortion a user reported in discord. I don't believe any of these are the issue, but hey. Why not fix the stuff while I'm there?

1. PCM decoder: reject empty and truncated input instead of silently returning short/empty buffers. Previously, `chunks_exact()` would quietly drop trailing bytes and produce zero-length decoded output with no error, creating silent gaps in the audio stream.

2. duration_us: round to nearest microsecond instead of truncating. The old floor-division was inconsistent with the remainder-tracking in advance_cursor(), creating a systematic ~1µs/buffer bias that could cause premature buffer drops at non-48kHz sample rates.

3. Message router: log on first channel send failure and stop retrying, instead of silently discarding all data via `let _ =`. A dropped audio receiver now produces a single error-level log line rather than complete silence with no diagnostic output.