### PR TITLE
feat!: Use raw monotonic clock for NTP-immune time sync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,9 @@ crossbeam = "0.8"
 parking_lot = "0.12"
 typed-builder = "0.23.2"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 tokio-test = "0.4"
 env_logger = "0.11"

--- a/src/audio/synced_player.rs
+++ b/src/audio/synced_player.rs
@@ -247,6 +247,7 @@ impl SyncedPlayer {
     /// # use parking_lot::Mutex;
     /// # use sendspin::audio::{AudioFormat, Codec, SyncedPlayer};
     /// # use sendspin::sync::ClockSync;
+    /// # use sendspin::DefaultClock;
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let format = AudioFormat {
     ///     codec: Codec::Pcm,
@@ -255,7 +256,7 @@ impl SyncedPlayer {
     ///     bit_depth: 24,
     ///     codec_header: None,
     /// };
-    /// let clock_sync = Arc::new(Mutex::new(ClockSync::new()));
+    /// let clock_sync = Arc::new(Mutex::new(ClockSync::new(Arc::new(DefaultClock::new()))));
     /// let player = SyncedPlayer::with_process_callback(
     ///     format, clock_sync, None,
     ///     100, false,
@@ -511,17 +512,14 @@ impl SyncedPlayer {
                             }
 
                             if schedule.reanchor || force_reanchor {
-                                if let Some(client_micros) =
-                                    sync.instant_to_client_micros(playback_instant)
+                                let client_micros = sync.instant_to_client_micros(playback_instant);
+                                if let Some(server_time) =
+                                    sync.client_to_server_micros(client_micros)
                                 {
-                                    if let Some(server_time) =
-                                        sync.client_to_server_micros(client_micros)
-                                    {
-                                        let mut queue = queue.lock();
-                                        queue.cursor_us = server_time;
-                                        queue.cursor_remainder = 0;
-                                        queue.force_reanchor = false;
-                                    }
+                                    let mut queue = queue.lock();
+                                    queue.cursor_us = server_time;
+                                    queue.cursor_remainder = 0;
+                                    queue.force_reanchor = false;
                                 }
                                 schedule = CorrectionSchedule::default();
                                 insert_counter = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub use protocol::client::{Connection, Controller, ProtocolClient};
 pub use protocol::client_builder::ProtocolClientBuilder;
 pub use protocol::messages::ServerHello;
 pub use scheduler::AudioScheduler;
+pub use sync::raw_clock::{Clock, DefaultClock};
 
 /// Result type for sendspin operations
 pub type Result<T> = std::result::Result<T, error::Error>;

--- a/src/protocol/client.rs
+++ b/src/protocol/client.rs
@@ -6,6 +6,7 @@ use crate::protocol::messages::{
     ClientCommand, ClientGoodbye, ClientHello, ClientState, ClientTime, ControllerCommand,
     ControllerCommandType, GoodbyeReason, Message, RepeatMode,
 };
+use crate::sync::raw_clock::Clock;
 use crate::sync::ClockSync;
 use futures_util::{
     stream::{SplitSink, SplitStream},
@@ -13,7 +14,6 @@ use futures_util::{
 };
 use parking_lot::Mutex;
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::net::TcpStream;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
@@ -417,6 +417,7 @@ impl ProtocolClient {
         request: R,
         hello: ClientHello,
         initial_state: ClientState,
+        clock: Arc<dyn Clock>,
     ) -> Result<Self, Error>
     where
         R: IntoClientRequest + Unpin,
@@ -516,11 +517,12 @@ impl ProtocolClient {
         let (visualizer_tx, visualizer_rx) = unbounded_channel();
         let (message_tx, message_rx) = unbounded_channel();
 
-        let clock_sync = Arc::new(Mutex::new(ClockSync::new()));
+        let clock_sync = Arc::new(Mutex::new(ClockSync::new(Arc::clone(&clock))));
         let ws_tx = Arc::new(tokio::sync::Mutex::new(write));
 
         // Spawn message router task
         let clock_sync_clone = Arc::clone(&clock_sync);
+        let clock_router = Arc::clone(&clock);
         let router_handle = tokio::spawn(async move {
             Self::message_router(
                 read_temp,
@@ -529,6 +531,7 @@ impl ProtocolClient {
                 visualizer_tx,
                 message_tx,
                 clock_sync_clone,
+                clock_router,
             )
             .await;
         });
@@ -548,13 +551,7 @@ impl ProtocolClient {
                     // Acquire the write lock in a block so it's always
                     // released before sleeping, even on error paths.
                     let mut tx = ws_tx_sync.lock().await;
-                    let t1 = match SystemTime::now().duration_since(UNIX_EPOCH) {
-                        Ok(d) => d.as_micros() as i64,
-                        Err(e) => {
-                            log::warn!("Clock before Unix epoch, skipping sync send: {}", e);
-                            break 'send false;
-                        }
-                    };
+                    let t1 = clock.now_micros();
                     let msg = Message::ClientTime(ClientTime {
                         client_transmitted: t1,
                     });
@@ -608,6 +605,7 @@ impl ProtocolClient {
         visualizer_tx: UnboundedSender<VisualizerChunk>,
         message_tx: UnboundedSender<Message>,
         clock_sync: Arc<Mutex<ClockSync>>,
+        clock: Arc<dyn Clock>,
     ) {
         let mut audio_closed = false;
         let mut artwork_closed = false;
@@ -668,7 +666,7 @@ impl ProtocolClient {
                 Ok(WsMessage::Text(text)) => {
                     // Capture receive time before deserialization so
                     // t4 is as close to the true arrival time as possible.
-                    let receive_time = SystemTime::now();
+                    let t4 = clock.now_micros();
                     log::debug!("Received text message: {}", text);
                     match serde_json::from_str::<Message>(&text) {
                         Ok(msg) => {
@@ -677,23 +675,12 @@ impl ProtocolClient {
                             // and intentionally NOT forwarded to message_rx
                             // consumers — it's an internal protocol detail.
                             if let Message::ServerTime(ref st) = msg {
-                                match receive_time.duration_since(UNIX_EPOCH) {
-                                    Ok(d) => {
-                                        let t4 = d.as_micros() as i64;
-                                        clock_sync.lock().update(
-                                            st.client_transmitted,
-                                            st.server_received,
-                                            st.server_transmitted,
-                                            t4,
-                                        );
-                                    }
-                                    Err(e) => {
-                                        log::warn!(
-                                            "Clock before Unix epoch, skipping sync sample: {}",
-                                            e
-                                        );
-                                    }
-                                }
+                                clock_sync.lock().update(
+                                    st.client_transmitted,
+                                    st.server_received,
+                                    st.server_transmitted,
+                                    t4,
+                                );
                             } else if !message_closed && message_tx.send(msg).is_err() {
                                 log::error!(
                                     "Message receiver dropped — messages will be discarded"

--- a/src/protocol/client_builder.rs
+++ b/src/protocol/client_builder.rs
@@ -5,7 +5,9 @@ use crate::protocol::messages::{
     ArtworkV1Support, AudioFormatSpec, ClientHello, ClientState, ClientSyncState, DeviceInfo,
     PlayerState, PlayerV1Support, VisualizerV1Support,
 };
+use crate::sync::raw_clock::{Clock, DefaultClock};
 use crate::ProtocolClient;
+use std::sync::Arc;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use typed_builder::TypedBuilder;
 
@@ -78,6 +80,7 @@ impl From<ProtocolClientBuilderRaw> for ProtocolClientBuilder {
             software_version: raw.software_version,
             supported_roles,
             player_v1_support,
+            clock: Arc::new(DefaultClock::new()),
             artwork_v1_support: raw.artwork_v1_support,
             visualizer_v1_support: raw.visualizer_v1_support,
             initial_player_state: raw.initial_player_state,
@@ -140,6 +143,7 @@ pub struct ProtocolClientBuilder {
     artwork_v1_support: Option<ArtworkV1Support>,
     visualizer_v1_support: Option<VisualizerV1Support>,
     initial_player_state: Option<PlayerState>,
+    clock: Arc<dyn Clock>,
 }
 
 impl ProtocolClientBuilder {
@@ -156,6 +160,17 @@ impl ProtocolClientBuilder {
     /// Get the player v1 support configuration
     pub fn player_v1_support(&self) -> Option<&PlayerV1Support> {
         self.player_v1_support.as_ref()
+    }
+
+    /// Override the default clock with a custom implementation.
+    ///
+    /// By default, the builder uses [`DefaultClock`] which reads
+    /// `CLOCK_MONOTONIC_RAW` on Linux (immune to NTP slew) and the
+    /// platform's native raw monotonic source elsewhere. Override this
+    /// for testing or for platforms with alternative high-precision clocks.
+    pub fn clock(mut self, clock: Arc<dyn Clock>) -> Self {
+        self.clock = clock;
+        self
     }
 
     /// Connect to Sendspin server.
@@ -188,6 +203,6 @@ impl ProtocolClientBuilder {
             player: self.initial_player_state,
         };
 
-        ProtocolClient::connect(request, hello, initial_state).await
+        ProtocolClient::connect(request, hello, initial_state, self.clock).await
     }
 }

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -224,7 +224,7 @@ pub enum ConnectionReason {
 /// Client time sync message
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ClientTime {
-    /// Client transmission timestamp (Unix microseconds)
+    /// Client transmission timestamp (raw monotonic microseconds)
     pub client_transmitted: i64,
 }
 

--- a/src/sync/clock.rs
+++ b/src/sync/clock.rs
@@ -1,7 +1,9 @@
 // ABOUTME: Clock synchronization implementation
 // ABOUTME: Drift-aware time sync with RTT estimation and server/client time conversion
 
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use super::raw_clock::{Clock, DefaultClock};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 const ADAPTIVE_FORGETTING_CUTOFF: f64 = 0.75;
 
@@ -183,7 +185,6 @@ pub enum SyncQuality {
 }
 
 /// Clock synchronization state
-#[derive(Debug)]
 pub struct ClockSync {
     /// Last known RTT in microseconds
     rtt_micros: Option<i64>,
@@ -191,23 +192,45 @@ pub struct ClockSync {
     last_update: Option<Instant>,
     /// Drift-aware time filter
     filter: TimeFilter,
+    /// Raw monotonic clock used for timestamps
+    clock: Arc<dyn Clock>,
+}
+
+impl std::fmt::Debug for ClockSync {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClockSync")
+            .field("rtt_micros", &self.rtt_micros)
+            .field("last_update", &self.last_update)
+            .field("filter", &self.filter)
+            .finish()
+    }
 }
 
 impl ClockSync {
-    /// Create a new clock synchronization instance
-    pub fn new() -> Self {
+    /// Create a new clock synchronization instance with the given clock.
+    pub fn new(clock: Arc<dyn Clock>) -> Self {
         Self {
             rtt_micros: None,
             last_update: None,
             filter: TimeFilter::new(0.01, 1.001),
+            clock,
         }
     }
 
-    /// Update clock sync with new measurement
-    /// t1 = client_transmitted (Unix µs)
-    /// t2 = server_received (server loop µs)
-    /// t3 = server_transmitted (server loop µs)
-    /// t4 = client_received (Unix µs)
+    /// Get a clone of the underlying clock.
+    ///
+    /// Useful for generating timestamps (t1, t4) in the same timebase
+    /// that the filter operates on, without holding the `ClockSync` lock.
+    pub fn clock(&self) -> Arc<dyn Clock> {
+        Arc::clone(&self.clock)
+    }
+
+    /// Update clock sync with new measurement.
+    ///
+    /// - `t1` = client_transmitted (raw monotonic µs from [`Clock::now_micros`])
+    /// - `t2` = server_received (server loop µs)
+    /// - `t3` = server_transmitted (server loop µs)
+    /// - `t4` = client_received (raw monotonic µs from [`Clock::now_micros`])
     pub fn update(&mut self, t1: i64, t2: i64, t3: i64, t4: i64) {
         // RTT = (t4 - t1) - (t3 - t2)
         let rtt = (t4 - t1) - (t3 - t2);
@@ -271,33 +294,12 @@ impl ClockSync {
     }
 
     fn client_micros_to_instant(&self, client_micros: i64) -> Option<Instant> {
-        let now_unix = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .ok()?
-            .as_micros() as i64;
-        let now_instant = Instant::now();
-        let delta_micros = client_micros - now_unix;
-
-        if delta_micros >= 0 {
-            Some(now_instant + Duration::from_micros(delta_micros as u64))
-        } else {
-            now_instant.checked_sub(Duration::from_micros((-delta_micros) as u64))
-        }
+        self.clock.micros_to_instant(client_micros)
     }
 
-    /// Convert a local Instant to client Unix microseconds.
-    pub fn instant_to_client_micros(&self, instant: Instant) -> Option<i64> {
-        let now_unix = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .ok()?
-            .as_micros() as i64;
-        let now_instant = Instant::now();
-        let delta_micros = if instant >= now_instant {
-            instant.duration_since(now_instant).as_micros() as i64
-        } else {
-            -(now_instant.duration_since(instant).as_micros() as i64)
-        };
-        Some(now_unix + delta_micros)
+    /// Convert a local Instant to client clock microseconds.
+    pub fn instant_to_client_micros(&self, instant: Instant) -> i64 {
+        self.clock.instant_to_micros(instant)
     }
 
     /// Get sync quality based on RTT
@@ -309,7 +311,13 @@ impl ClockSync {
         }
     }
 
-    /// Check if sync is stale (>5 seconds old)
+    /// Check if sync is stale (>5 seconds since last update).
+    ///
+    /// Uses `Instant::now()` (not the injected [`Clock`]) because staleness
+    /// is a wall-clock concept — we're measuring real elapsed time since the
+    /// last successful sync round, regardless of which timebase the filter
+    /// operates on. This means `is_stale()` always reflects real time even
+    /// when a mock clock is injected for testing.
     pub fn is_stale(&self) -> bool {
         match self.last_update {
             Some(last) => last.elapsed() > Duration::from_secs(5),
@@ -325,7 +333,7 @@ impl ClockSync {
 
 impl Default for ClockSync {
     fn default() -> Self {
-        Self::new()
+        Self::new(Arc::new(DefaultClock::new()))
     }
 }
 

--- a/src/sync/clock.rs
+++ b/src/sync/clock.rs
@@ -261,7 +261,7 @@ impl ClockSync {
         self.rtt_micros
     }
 
-    /// Convert server loop microseconds to client Unix microseconds
+    /// Convert server loop microseconds to client clock microseconds
     pub fn server_to_client_micros(&self, server_micros: i64) -> Option<i64> {
         if !self.filter.is_synchronized() {
             return None;
@@ -269,7 +269,7 @@ impl ClockSync {
         self.filter.compute_client_time(server_micros)
     }
 
-    /// Convert client Unix microseconds to server loop microseconds
+    /// Convert client clock microseconds to server loop microseconds
     pub fn client_to_server_micros(&self, client_micros: i64) -> Option<i64> {
         if !self.filter.is_synchronized() {
             return None;

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -3,5 +3,8 @@
 
 /// Clock synchronization implementation
 pub mod clock;
+/// Raw monotonic clock trait and platform implementations
+pub mod raw_clock;
 
 pub use clock::{ClockSync, SyncQuality};
+pub use raw_clock::{Clock, DefaultClock};

--- a/src/sync/raw_clock.rs
+++ b/src/sync/raw_clock.rs
@@ -85,6 +85,7 @@ pub struct DefaultClock {
     /// platforms where we derive microseconds from `Instant` arithmetic.
     /// On Linux this field is unused (we read `CLOCK_MONOTONIC_RAW` directly),
     /// but the cost of a single `Instant` isn't worth a `cfg` attr.
+    #[cfg_attr(target_os = "linux", allow(dead_code))]
     epoch: Instant,
 }
 
@@ -141,7 +142,7 @@ impl Clock for DefaultClock {
                 );
             }
         }
-        ts.tv_sec as i64 * 1_000_000 + ts.tv_nsec as i64 / 1_000
+        ts.tv_sec * 1_000_000 + ts.tv_nsec / 1_000
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/src/sync/raw_clock.rs
+++ b/src/sync/raw_clock.rs
@@ -1,0 +1,155 @@
+// ABOUTME: Clock trait and raw monotonic clock implementation
+// ABOUTME: Provides NTP-slew-immune time source for accurate clock synchronization
+
+use std::time::{Duration, Instant};
+
+/// A monotonic time source for clock synchronization.
+///
+/// Implementations must return microseconds from a stable, monotonic source
+/// that is **not** conditioned by NTP rate adjustments (slewing). On Linux,
+/// this means `CLOCK_MONOTONIC_RAW` rather than `CLOCK_MONOTONIC`.
+///
+/// # Why not `std::time::Instant`?
+///
+/// Rust's `Instant` uses `CLOCK_MONOTONIC` on Linux, which is subject to NTP
+/// frequency discipline. When NTP adjusts the tick rate to synchronize with
+/// upstream sources, `CLOCK_MONOTONIC` speeds up or slows down slightly. At
+/// audio-sync precision (~1ms), even small slew corrections (a few ms over
+/// minutes) can destabilize a Kalman filter that's tracking clock offset and
+/// drift between client and server.
+///
+/// On macOS (`mach_absolute_time`) and Windows (`QueryPerformanceCounter`),
+/// `Instant` is already raw/unconditioned, so this distinction only matters
+/// on Linux.
+pub trait Clock: Send + Sync + 'static {
+    /// Monotonic microseconds from an arbitrary epoch.
+    ///
+    /// The epoch is implementation-defined and need not relate to Unix time.
+    /// The only requirement is that successive calls return non-decreasing
+    /// values on a single thread, and the timebase is not NTP-conditioned.
+    fn now_micros(&self) -> i64;
+
+    /// Convert this clock's microseconds to a [`std::time::Instant`].
+    ///
+    /// This bridges between the raw monotonic timebase and Rust's `Instant`,
+    /// which is needed for interop with `tokio`, `cpal`, and the audio
+    /// scheduler. The default implementation samples both clocks and computes
+    /// the delta — the bridge error is typically under 10µs, bounded by
+    /// the time between the two clock reads (which can grow under scheduler
+    /// pressure, but is sub-microsecond in the common case).
+    ///
+    /// Returns `None` if the requested time is so far in the past that it
+    /// precedes `Instant`'s internal epoch (before process start).
+    fn micros_to_instant(&self, micros: i64) -> Option<Instant> {
+        let now_micros = self.now_micros();
+        let now_instant = Instant::now();
+        let delta = micros - now_micros;
+        if delta >= 0 {
+            Some(now_instant + Duration::from_micros(delta as u64))
+        } else {
+            now_instant.checked_sub(Duration::from_micros((-delta) as u64))
+        }
+    }
+
+    /// Convert a [`std::time::Instant`] to this clock's microseconds.
+    ///
+    /// Inverse of [`micros_to_instant`](Clock::micros_to_instant). Used during
+    /// re-anchoring to map the audio callback's playback instant back to the
+    /// clock domain for server-time conversion.
+    ///
+    /// The bridge error is typically under 10µs (see
+    /// [`micros_to_instant`](Clock::micros_to_instant) for details).
+    /// Sub-microsecond truncation from `Duration::as_micros()` introduces
+    /// a consistent -0 to -1µs bias, which the Kalman filter absorbs trivially.
+    fn instant_to_micros(&self, instant: Instant) -> i64 {
+        let now_micros = self.now_micros();
+        let now_instant = Instant::now();
+        let delta = if instant >= now_instant {
+            instant.duration_since(now_instant).as_micros() as i64
+        } else {
+            -(now_instant.duration_since(instant).as_micros() as i64)
+        };
+        now_micros + delta
+    }
+}
+
+/// Default clock implementation using the best available raw monotonic source.
+///
+/// | Platform | Source | NTP-immune? |
+/// |----------|--------|-------------|
+/// | Linux | `CLOCK_MONOTONIC_RAW` | Yes |
+/// | macOS | `mach_absolute_time` (via `Instant`) | Yes |
+/// | Windows | `QueryPerformanceCounter` (via `Instant`) | Yes |
+pub struct DefaultClock {
+    /// `Instant` captured at construction, used as the epoch for non-Linux
+    /// platforms where we derive microseconds from `Instant` arithmetic.
+    /// On Linux this field is unused (we read `CLOCK_MONOTONIC_RAW` directly),
+    /// but the cost of a single `Instant` isn't worth a `cfg` attr.
+    epoch: Instant,
+}
+
+impl DefaultClock {
+    /// Create a new default clock.
+    pub fn new() -> Self {
+        Self {
+            epoch: Instant::now(),
+        }
+    }
+}
+
+impl Default for DefaultClock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for DefaultClock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DefaultClock").finish()
+    }
+}
+
+impl Clock for DefaultClock {
+    #[cfg(target_os = "linux")]
+    fn now_micros(&self) -> i64 {
+        let mut ts = libc::timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        };
+        // SAFETY: `clock_gettime` writes to the provided pointer and
+        // `CLOCK_MONOTONIC_RAW` is always available on Linux ≥ 2.6.28.
+        // We pass a valid, aligned, stack-allocated `timespec`.
+        let ret = unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC_RAW, &mut ts) };
+        if ret != 0 {
+            // CLOCK_MONOTONIC_RAW can fail in heavily restricted containers
+            // (e.g. seccomp filters) or on very old kernels. Fall back to
+            // CLOCK_MONOTONIC which is NTP-conditioned but still monotonic.
+            log::error!(
+                "CLOCK_MONOTONIC_RAW unavailable (errno {}), falling back to CLOCK_MONOTONIC",
+                std::io::Error::last_os_error()
+            );
+            // SAFETY: same pointer validity as above; CLOCK_MONOTONIC is
+            // universally available on all Linux kernels.
+            let ret2 = unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts) };
+            if ret2 != 0 {
+                // Both clocks failed — this is essentially impossible on any
+                // real Linux system, but if it happens, ts is still zeroed from
+                // initialization. Log and accept 0 as the degenerate case.
+                log::error!(
+                    "CLOCK_MONOTONIC also failed (errno {}); returning epoch (0)",
+                    std::io::Error::last_os_error()
+                );
+            }
+        }
+        ts.tv_sec as i64 * 1_000_000 + ts.tv_nsec as i64 / 1_000
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn now_micros(&self) -> i64 {
+        // On macOS and Windows, Instant is already a raw/unconditioned source.
+        // The cast from u128 to i64 is safe: i64::MAX microseconds is ~292,277
+        // years of uptime. Use try_from to be explicit rather than silently
+        // truncating.
+        i64::try_from(Instant::now().duration_since(self.epoch).as_micros()).unwrap_or(i64::MAX)
+    }
+}

--- a/tests/clock_sync.rs
+++ b/tests/clock_sync.rs
@@ -1,4 +1,5 @@
-use sendspin::sync::{ClockSync, SyncQuality};
+use sendspin::sync::{ClockSync, DefaultClock, SyncQuality};
+use std::sync::Arc;
 
 /// Assert that two values are within tolerance (microseconds precision)
 fn assert_within(actual: Option<i64>, expected: i64, tolerance: i64) {
@@ -16,7 +17,7 @@ fn assert_within(actual: Option<i64>, expected: i64, tolerance: i64) {
 
 #[test]
 fn test_fresh_clock_sync_initial_state() {
-    let sync = ClockSync::new();
+    let sync = ClockSync::new(Arc::new(DefaultClock::new()));
 
     assert_eq!(sync.rtt_micros(), None);
     assert!(!sync.is_synchronized());
@@ -28,7 +29,7 @@ fn test_fresh_clock_sync_initial_state() {
 
 #[test]
 fn test_single_update_not_synchronized() {
-    let mut sync = ClockSync::new();
+    let mut sync = ClockSync::new(Arc::new(DefaultClock::new()));
 
     // One sample isn't enough for the filter to converge (needs count >= 2)
     sync.update(1_000_000, 500_000, 500_010, 1_000_040);
@@ -47,7 +48,7 @@ fn test_single_update_not_synchronized() {
 
 #[test]
 fn test_clock_sync_rtt_calculation() {
-    let mut sync = ClockSync::new();
+    let mut sync = ClockSync::new(Arc::new(DefaultClock::new()));
 
     // Simulate sync: client sends at 1000µs, server receives at 500µs (server loop time)
     let t1 = 1_000_000; // Client transmitted (Unix µs)
@@ -63,7 +64,7 @@ fn test_clock_sync_rtt_calculation() {
 
 #[test]
 fn test_server_to_client_conversion() {
-    let mut sync = ClockSync::new();
+    let mut sync = ClockSync::new(Arc::new(DefaultClock::new()));
 
     let t1 = 1_000_000;
     let t2 = 1_005_100;
@@ -80,7 +81,7 @@ fn test_server_to_client_conversion() {
 
 #[test]
 fn test_sync_quality() {
-    let mut sync = ClockSync::new();
+    let mut sync = ClockSync::new(Arc::new(DefaultClock::new()));
 
     // Good RTT (30µs)
     sync.update(1_000_000, 500_000, 500_010, 1_000_040);
@@ -93,7 +94,7 @@ fn test_sync_quality() {
 
 #[test]
 fn test_sync_quality_recovery() {
-    let mut sync = ClockSync::new();
+    let mut sync = ClockSync::new(Arc::new(DefaultClock::new()));
 
     // Start with degraded RTT (75ms)
     sync.update(1_000_000, 600_000, 600_010, 1_075_010);
@@ -106,7 +107,7 @@ fn test_sync_quality_recovery() {
 
 #[test]
 fn test_sync_quality_unchanged_after_high_rtt() {
-    let mut sync = ClockSync::new();
+    let mut sync = ClockSync::new(Arc::new(DefaultClock::new()));
 
     // First, establish a good RTT (30µs)
     sync.update(1_000_000, 500_000, 500_010, 1_000_040);
@@ -126,7 +127,7 @@ fn test_sync_quality_unchanged_after_high_rtt() {
 
 #[test]
 fn test_timestamp_boundary_zero_values() {
-    let mut sync = ClockSync::new();
+    let mut sync = ClockSync::new(Arc::new(DefaultClock::new()));
 
     // All-zero timestamps: RTT = (0 - 0) - (0 - 0) = 0, which is valid
     sync.update(0, 0, 0, 0);
@@ -135,7 +136,7 @@ fn test_timestamp_boundary_zero_values() {
 
 #[test]
 fn test_clock_drift_correction() {
-    let mut sync = ClockSync::new();
+    let mut sync = ClockSync::new(Arc::new(DefaultClock::new()));
 
     sync.update(1_000_000, 1_005_100, 1_005_100, 1_000_200);
     sync.update(2_000_000, 2_005_200, 2_005_200, 2_000_200);
@@ -147,7 +148,7 @@ fn test_clock_drift_correction() {
 
 #[test]
 fn test_diverged_drift_returns_none() {
-    let mut sync = ClockSync::new();
+    let mut sync = ClockSync::new(Arc::new(DefaultClock::new()));
 
     // Two samples 10µs apart where the NTP offset drops from 100 to 88,
     // giving drift = -1.2 — far beyond any real hardware clock skew.
@@ -167,7 +168,7 @@ fn test_diverged_drift_returns_none() {
 
 #[test]
 fn test_negative_rtt_discarded() {
-    let mut sync = ClockSync::new();
+    let mut sync = ClockSync::new(Arc::new(DefaultClock::new()));
 
     // Craft timestamps where t4 < t1 (response "before" request),
     // producing negative RTT. Should be silently discarded.
@@ -181,7 +182,7 @@ fn test_negative_rtt_discarded() {
 
 #[test]
 fn test_zero_rtt_accepted() {
-    let mut sync = ClockSync::new();
+    let mut sync = ClockSync::new(Arc::new(DefaultClock::new()));
 
     // RTT = 0 is legitimate on localhost. The filter clamps max_error
     // to 1µs so zero-variance samples don't corrupt covariance.

--- a/tests/protocol_client.rs
+++ b/tests/protocol_client.rs
@@ -51,14 +51,13 @@ async fn start_test_server() -> (
 
         // Forward all subsequent messages to the channel
         while let Some(Ok(msg)) = ws.next().await {
-            match msg {
-                WsMessage::Text(text) => {
-                    if tx.send(text).is_err() {
-                        break;
-                    }
-                }
+            let text = match msg {
+                WsMessage::Text(text) => text,
                 WsMessage::Close(_) => break,
-                _ => {}
+                _ => continue,
+            };
+            if tx.send(text).is_err() {
+                break;
             }
         }
     });
@@ -450,14 +449,13 @@ async fn start_test_server_with_roles(
         ws.send(WsMessage::Text(server_hello)).await.unwrap();
 
         while let Some(Ok(msg)) = ws.next().await {
-            match msg {
-                WsMessage::Text(text) => {
-                    if tx.send(text).is_err() {
-                        break;
-                    }
-                }
+            let text = match msg {
+                WsMessage::Text(text) => text,
                 WsMessage::Close(_) => break,
-                _ => {}
+                _ => continue,
+            };
+            if tx.send(text).is_err() {
+                break;
             }
         }
     });

--- a/tests/protocol_messages.rs
+++ b/tests/protocol_messages.rs
@@ -556,12 +556,13 @@ fn test_server_time_deserialization() {
 
 #[test]
 fn test_server_time_fields_feed_clock_sync() {
-    use sendspin::sync::ClockSync;
+    use sendspin::sync::{ClockSync, DefaultClock};
+    use std::sync::Arc;
 
     // Simulate two sync rounds using the same field mapping
     // that message_router uses: st.client_transmitted = t1,
     // st.server_received = t2, st.server_transmitted = t3.
-    let mut sync = ClockSync::new();
+    let mut sync = ClockSync::new(Arc::new(DefaultClock::new()));
     assert!(!sync.is_synchronized());
 
     let st1 = ServerTime {

--- a/tests/raw_clock.rs
+++ b/tests/raw_clock.rs
@@ -1,0 +1,248 @@
+use sendspin::sync::{Clock, ClockSync, DefaultClock};
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// A controllable clock for deterministic testing.
+///
+/// Callers advance time explicitly via [`MockClock::advance`], making
+/// tests independent of real wall-clock timing.
+struct MockClock {
+    micros: AtomicI64,
+}
+
+impl MockClock {
+    fn new(initial: i64) -> Self {
+        Self {
+            micros: AtomicI64::new(initial),
+        }
+    }
+
+    fn set(&self, micros: i64) {
+        self.micros.store(micros, Ordering::SeqCst);
+    }
+
+    fn advance(&self, delta_micros: i64) {
+        self.micros.fetch_add(delta_micros, Ordering::SeqCst);
+    }
+}
+
+impl Clock for MockClock {
+    fn now_micros(&self) -> i64 {
+        self.micros.load(Ordering::SeqCst)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DefaultClock tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_default_clock_monotonic() {
+    let clock = DefaultClock::new();
+    let t1 = clock.now_micros();
+    // Yield to guarantee a nonzero time delta — unlike black_box on an
+    // empty loop body, yield_now() always costs real scheduler time.
+    std::thread::yield_now();
+    let t2 = clock.now_micros();
+    assert!(t2 >= t1, "clock must be monotonically non-decreasing");
+}
+
+#[test]
+fn test_default_clock_micros_to_instant_roundtrip() {
+    let clock = DefaultClock::new();
+    let now_micros = clock.now_micros();
+    let instant = clock
+        .micros_to_instant(now_micros)
+        .expect("conversion should succeed for current time");
+
+    // The round-trip should land very close to Instant::now().
+    let diff = Instant::now().duration_since(instant);
+    assert!(
+        diff < Duration::from_millis(5),
+        "round-trip drift too large: {:?}",
+        diff
+    );
+}
+
+#[test]
+fn test_default_clock_instant_to_micros_roundtrip() {
+    let clock = DefaultClock::new();
+    let now = Instant::now();
+    let micros = clock.instant_to_micros(now);
+    let back = clock
+        .micros_to_instant(micros)
+        .expect("conversion should succeed");
+
+    // Allow ±1ms for the two clock samples.
+    let diff = if back >= now {
+        back.duration_since(now)
+    } else {
+        now.duration_since(back)
+    };
+    assert!(
+        diff < Duration::from_millis(1),
+        "roundtrip error too large: {:?}",
+        diff
+    );
+}
+
+#[test]
+fn test_default_clock_future_micros_to_instant() {
+    let clock = DefaultClock::new();
+    let future = clock.now_micros() + 1_000_000; // 1 second in the future
+    let instant = clock
+        .micros_to_instant(future)
+        .expect("future time should convert");
+    assert!(
+        instant > Instant::now(),
+        "future micros should map to a future Instant"
+    );
+}
+
+#[test]
+fn test_default_clock_past_micros_to_instant() {
+    let clock = DefaultClock::new();
+    let past = clock.now_micros() - 1_000_000; // 1 second in the past
+    let instant = clock
+        .micros_to_instant(past)
+        .expect("past time should convert");
+    assert!(
+        instant < Instant::now(),
+        "past micros should map to a past Instant"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// MockClock tests — proving the trait is injectable
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_mock_clock_deterministic() {
+    let clock = MockClock::new(1_000_000);
+    assert_eq!(clock.now_micros(), 1_000_000);
+
+    clock.advance(500);
+    assert_eq!(clock.now_micros(), 1_000_500);
+}
+
+#[test]
+fn test_clock_sync_with_mock_clock() {
+    let clock = Arc::new(MockClock::new(100_000));
+    let mut sync = ClockSync::new(clock.clone() as Arc<dyn Clock>);
+
+    // Simulate two NTP-style sync rounds with the mock clock.
+    // Round 1: client at 100_000µs, server at 105_000µs, RTT ~200µs
+    clock.set(100_000);
+    let t1 = clock.now_micros();
+    let t2 = 105_100; // server received
+    let t3 = 105_110; // server transmitted
+    clock.set(100_200); // client received
+    let t4 = clock.now_micros();
+    sync.update(t1, t2, t3, t4);
+
+    // Round 2: advance client by 1 second
+    clock.set(1_100_000);
+    let t1_2 = clock.now_micros();
+    let t2_2 = 1_105_100;
+    let t3_2 = 1_105_110;
+    clock.set(1_100_200);
+    let t4_2 = clock.now_micros();
+    sync.update(t1_2, t2_2, t3_2, t4_2);
+
+    assert!(
+        sync.is_synchronized(),
+        "should be synchronized after 2 samples"
+    );
+
+    // Verify conversion: server time 1_105_000 should map to ~client 1_100_000
+    let client_micros = sync.server_to_client_micros(1_105_000);
+    let client = client_micros.expect("should have a value");
+    let diff = (client - 1_100_000).abs();
+    assert!(
+        diff < 50,
+        "server→client conversion off by {}µs (expected ~0)",
+        diff
+    );
+}
+
+#[test]
+fn test_clock_sync_accessor_returns_injected_clock() {
+    let clock = Arc::new(MockClock::new(42_000));
+    let sync = ClockSync::new(clock.clone() as Arc<dyn Clock>);
+
+    // The clock() accessor should return the same clock we injected,
+    // producing the same value.
+    assert_eq!(sync.clock().now_micros(), 42_000);
+}
+
+#[test]
+fn test_clock_sync_instant_to_client_micros_is_infallible() {
+    // instant_to_client_micros returns i64 (not Option), verifying
+    // the API reflects that it cannot fail.
+    let clock = Arc::new(MockClock::new(500_000));
+    let sync = ClockSync::new(clock as Arc<dyn Clock>);
+    let result: i64 = sync.instant_to_client_micros(Instant::now());
+    // The mock clock is at 500_000µs; Instant::now() maps to roughly that.
+    // We just verify it returns a reasonable value (not zero, not negative).
+    assert!(result > 0, "should return a positive value, got {}", result);
+}
+
+// ---------------------------------------------------------------------------
+// micros_to_instant edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_micros_to_instant_far_past_returns_none() {
+    let clock = DefaultClock::new();
+    // Request a time far before the process started. On most platforms
+    // Instant's epoch is process start or boot time, so a negative
+    // microsecond value (or huge negative delta) should exceed the
+    // epoch and return None from checked_sub.
+    let very_far_past = clock.now_micros() - 1_000_000_000_000; // ~11.5 days before
+                                                                // This may or may not return None depending on platform uptime,
+                                                                // but we can at least verify it doesn't panic.
+    let _result = clock.micros_to_instant(very_far_past);
+}
+
+#[test]
+fn test_mock_clock_micros_to_instant_returns_none_for_unreachable_past() {
+    // MockClock at 0µs: requesting micros_to_instant(0) means delta = 0
+    // relative to mock, but the default bridge uses Instant::now() which
+    // is far from zero. Requesting a very negative value should trigger
+    // the checked_sub None path.
+    let clock = MockClock::new(1_000_000_000); // 1000 seconds
+                                               // Ask for a time 1_000_000_000µs before the mock's "now" — this is
+                                               // ~1000 seconds before Instant::now(), which will likely be before
+                                               // boot on many systems.
+    let result = clock.micros_to_instant(0);
+    // On short-uptime systems this is None; on long-uptime it's Some.
+    // Either way, it must not panic.
+    let _ = result;
+}
+
+// ---------------------------------------------------------------------------
+// Bridge round-trip with MockClock
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_mock_clock_bridge_round_trip() {
+    // The MockClock uses the default bridge implementations which sample
+    // both MockClock::now_micros() and Instant::now(). Verify the
+    // round-trip micros → Instant → micros stays within tolerance.
+    let clock = MockClock::new(500_000);
+    let original = 500_000i64;
+    if let Some(instant) = clock.micros_to_instant(original) {
+        let back = clock.instant_to_micros(instant);
+        let diff = (back - original).abs();
+        // Allow up to 1ms — the two clock reads in the bridge introduce
+        // error proportional to wall-clock time between them.
+        assert!(
+            diff < 1_000,
+            "MockClock bridge round-trip error too large: {}µs",
+            diff
+        );
+    }
+    // If micros_to_instant returned None, the mock's value was before
+    // Instant's epoch — that's a valid outcome for this test.
+}


### PR DESCRIPTION
As per a discussion in the discord, using the 'raw' non-NTP-skewed monotonic clock is preferable when using Kalman filters for sync the way we do. This *does* have one more (small) API breaking change, which I swear is the last one. I can quit any time I want! I'm not addicted to breaking changes, I swear! 😅 (Also, added a ClockSync::default() for almost everyone who was actually using ::new() directly before).

Replace SystemTime/UNIX_EPOCH throughout the sync path with an injectable Clock trait backed by CLOCK_MONOTONIC_RAW on Linux (and Instant on macOS/Windows where it's already unconditioned). This eliminates NTP slew interference that can destabilize the Kalman filter at audio-sync precision.

Key changes:
- Add Clock trait + DefaultClock with platform-specific implementations
- Inject clock into ClockSync and ProtocolClient via the builder
- instant_to_client_micros is now infallible (returns i64, not Option)
- Flatten nested Option chains in synced_player reanchor path
- Add MockClock and comprehensive tests for the new trait

BREAKING CHANGE: ClockSync::new() now requires an Arc<dyn Clock> argument.