### PR TITLE
test: close coverage gaps flagged by cargo mutants

### DIFF
--- a/src/audio/gain.rs
+++ b/src/audio/gain.rs
@@ -870,4 +870,63 @@ mod tests {
             data[19]
         );
     }
+
+    #[test]
+    fn test_is_muted_reports_false_when_unmuted() {
+        // `is_muted()` must reflect both states. The other tests all exercise
+        // the `true` branch (asserting the *setter* took effect), so this one
+        // pins the `false` branch and the `true → false` transition.
+        let gc = GainControl::new(100, false);
+        assert!(!gc.is_muted());
+        gc.set_mute(true);
+        gc.set_mute(false);
+        assert!(
+            !gc.is_muted(),
+            "set_mute(false) should clear the muted flag"
+        );
+    }
+
+    #[test]
+    fn test_debug_includes_volume_and_mute_fields() {
+        // The custom `fmt::Debug` impl must expose volume and mute state so
+        // debug prints are actually useful. Pin the contract rather than
+        // relying on the impl staying in sync with its fields.
+        let gc = GainControl::new(42, true);
+        let s = format!("{:?}", gc);
+        assert!(s.contains("42"), "Debug output missing volume: {s}");
+        assert!(s.contains("true"), "Debug output missing mute state: {s}");
+    }
+
+    #[test]
+    fn test_apply_stereo_buffer_shorter_than_ramp() {
+        // Pins the `data.len() / channels` frame calculation: for a stereo
+        // buffer with fewer frames than `ramp_frames_remaining`, the split
+        // point must be `frames * channels`, not `data.len() * channels`
+        // (which would overrun the buffer) or any other arithmetic variant.
+        let mut ramp = GainRamp::new(1000, 1.0); // 20-frame ramp
+        let mut data = vec![1.0; 6]; // 3 stereo frames, well under the 20-frame ramp
+        ramp.apply(&mut data, 2, 0.0);
+
+        // All samples should have been touched by the ramp (gain < 1.0 as it
+        // decays toward 0.0). Paired left/right in each frame share a gain.
+        for i in 0..3 {
+            assert!(
+                data[i * 2] < 1.0 && data[i * 2] >= 0.0,
+                "frame {i} L out of expected range: {}",
+                data[i * 2]
+            );
+            assert!(
+                (data[i * 2] - data[i * 2 + 1]).abs() < 1e-6,
+                "frame {i} L/R differ: {} vs {}",
+                data[i * 2],
+                data[i * 2 + 1]
+            );
+        }
+
+        // Exactly 3 frames of ramp should have been consumed.
+        assert_eq!(
+            ramp.ramp_frames_remaining, 17,
+            "3 frames consumed from a 20-frame ramp should leave 17 remaining"
+        );
+    }
 }

--- a/src/audio/sync_correction.rs
+++ b/src/audio/sync_correction.rs
@@ -211,4 +211,55 @@ mod tests {
         );
         assert_eq!(schedule.drop_every_n_frames, 0);
     }
+
+    // -- Exact interval values --
+    //
+    // The tests above only check *which* field is set (drop vs insert).
+    // These pin down the actual interval arithmetic: `frames_error`, the
+    // `desired` / `max` corrections_per_sec cap, and the `interval_frames`
+    // rounding. Checking a single "correction engaged" bit lets the
+    // arithmetic drift silently; checking the computed cadence doesn't.
+
+    #[test]
+    fn test_drop_interval_below_speed_cap_matches_spec() {
+        // 5ms error at 48 kHz, already correcting (deadband threshold):
+        //   frames_error                = 5000 * 48000 / 1_000_000 = 240 frames
+        //   desired_corrections_per_sec = 240 / 2.0                = 120
+        //   max_corrections_per_sec     = 48000 * 0.04             = 1920 (not binding)
+        //   interval_frames             = round(48000 / 120)       = 400
+        let planner = CorrectionPlanner::new();
+        let s = planner.plan(5_000, 48_000, true);
+        assert_eq!(
+            s.drop_every_n_frames, 400,
+            "5ms drift should produce drop every 400 frames"
+        );
+        assert_eq!(s.insert_every_n_frames, 0);
+    }
+
+    #[test]
+    fn test_insert_interval_below_speed_cap_matches_spec() {
+        // Mirror of the drop test with a negative error.
+        let planner = CorrectionPlanner::new();
+        let s = planner.plan(-5_000, 48_000, true);
+        assert_eq!(
+            s.insert_every_n_frames, 400,
+            "-5ms drift should produce insert every 400 frames"
+        );
+        assert_eq!(s.drop_every_n_frames, 0);
+    }
+
+    #[test]
+    fn test_drop_interval_hits_max_speed_cap() {
+        // 200ms error — large enough that the desired rate exceeds the cap:
+        //   frames_error                = 200000 * 48000 / 1_000_000 = 9600
+        //   desired_corrections_per_sec = 9600 / 2.0                 = 4800
+        //   max_corrections_per_sec     = 48000 * 0.04               = 1920 (binding)
+        //   interval_frames             = round(48000 / 1920)        = 25
+        let planner = CorrectionPlanner::new();
+        let s = planner.plan(200_000, 48_000, true);
+        assert_eq!(
+            s.drop_every_n_frames, 25,
+            "large drift should be capped at max speed correction (interval = 25 frames)"
+        );
+    }
 }

--- a/src/audio/synced_player.rs
+++ b/src/audio/synced_player.rs
@@ -628,8 +628,11 @@ mod tests {
     // in gain.rs. Wiring tests require a real audio device (cpal Stream) and
     // cannot run in CI.
 
-    use super::PlaybackQueue;
+    use super::{PlaybackQueue, SyncedPlayer};
     use crate::audio::{AudioBuffer, AudioFormat, Codec, Sample};
+    use crate::error::Error;
+    use crate::sync::{ClockSync, DefaultClock};
+    use parking_lot::Mutex;
     use std::sync::Arc;
     use std::time::Instant;
 
@@ -649,6 +652,36 @@ mod tests {
         AudioFormat {
             channels: 1,
             ..test_format()
+        }
+    }
+
+    #[test]
+    fn test_build_rejects_zero_channels() {
+        // `SyncedPlayer::build` short-circuits on channels==0 *before* any
+        // cpal device access, so this test works regardless of whether the
+        // runner has audio hardware. Asserting on the specific error message
+        // (not just `is_err()`) pins the check to the explicit guard — any
+        // later failure (missing device, cpal rejecting the config) would
+        // surface a different message.
+        let format = AudioFormat {
+            codec: Codec::Pcm,
+            sample_rate: 48_000,
+            channels: 0,
+            bit_depth: 24,
+            codec_header: None,
+        };
+        let clock_sync = Arc::new(Mutex::new(ClockSync::new(Arc::new(DefaultClock::new()))));
+        let result = SyncedPlayer::new(format, clock_sync, None, 100, false);
+        let err = match result {
+            Ok(_) => panic!("channels=0 should be rejected"),
+            Err(e) => e,
+        };
+        match err {
+            Error::Output(msg) => assert!(
+                msg.contains("channels must be > 0"),
+                "expected 'channels must be > 0' error, got: {msg}"
+            ),
+            other => panic!("expected Error::Output, got {other:?}"),
         }
     }
 
@@ -1087,6 +1120,87 @@ mod tests {
         assert_eq!(queue.queue.len(), 1);
         assert_eq!(queue.queue[0].timestamp, 9_000);
         assert_eq!(queue.queue[0].samples[0], Sample(333));
+    }
+
+    #[test]
+    fn test_push_keeps_adjacent_buffers_inserted_in_reverse_order() {
+        // When buffer B is pushed *after* buffer A and they abut at the
+        // boundary (B.ts == A.end), the existing dedup check keeps both
+        // because `b.timestamp < new_end` is false at the boundary. The
+        // symmetric case — pushing the *earlier* buffer second — must also
+        // keep both: when we push the earlier buffer A and retain() walks
+        // B, we see `B.ts == new_end` (A.end). The dedup has to treat the
+        // boundary as *not* overlapping, otherwise we'd evict a buffer that
+        // simply abuts — a common pattern when chunks arrive out-of-order.
+        let mut queue = PlaybackQueue::new();
+        let format = test_format();
+
+        // Two 5ms adjacent chunks: A at [0, 5000), B at [5000, 10000).
+        let samples_a: Vec<Sample> = (0..240 * 2).map(|_| Sample(111)).collect();
+        let samples_b: Vec<Sample> = (0..240 * 2).map(|_| Sample(222)).collect();
+
+        // Push the *later* buffer (B) first …
+        queue.push(AudioBuffer {
+            timestamp: 5_000,
+            play_at: Instant::now(),
+            samples: Arc::from(samples_b.into_boxed_slice()),
+            format: format.clone(),
+        });
+        // … then push the *earlier* buffer (A). A.end == B.ts (boundary case).
+        queue.push(AudioBuffer {
+            timestamp: 0,
+            play_at: Instant::now(),
+            samples: Arc::from(samples_a.into_boxed_slice()),
+            format,
+        });
+
+        assert_eq!(
+            queue.queue.len(),
+            2,
+            "adjacent buffers pushed in reverse order should both be kept"
+        );
+        // Should also be sorted: A first, then B.
+        assert_eq!(queue.queue[0].timestamp, 0);
+        assert_eq!(queue.queue[1].timestamp, 5_000);
+    }
+
+    #[test]
+    fn test_next_frame_returns_final_frame_when_skip_lands_at_last_frame() {
+        // When the cursor skip lands `self.index` at exactly
+        // `samples.len() - channels`, there is still one playable frame at
+        // the tail of the buffer. The "is this buffer exhausted?" check in
+        // the outer match is `self.index + channels > c.samples.len()` —
+        // strictly greater — so `index == samples.len() - channels` falls
+        // through to the frame-return path. A non-strict comparison here
+        // would silently drop the last frame of every buffer whose skip
+        // landed on the final-frame boundary.
+        //
+        // Setup: 48-frame stereo buffer at ts=0, cursor at 980 µs.
+        //   skip_us     = 980 - 0                          = 980
+        //   skip_frames = 980 * 48_000 / 1_000_000         = 47
+        //   self.index  = 47 * 2                           = 94
+        //   samples.len = 48 * 2                           = 96
+        //   94 + 2 == 96 — keep buffer, return last frame.
+        let mut queue = PlaybackQueue::new();
+        let format = test_format();
+
+        // Distinctive sample values so we can assert *which* frame was returned.
+        let samples: Vec<Sample> = (0..48 * 2).map(Sample).collect();
+
+        queue.initialized = true;
+        queue.cursor_us = 980;
+        queue.queue.push_back(AudioBuffer {
+            timestamp: 0,
+            play_at: Instant::now(),
+            samples: Arc::from(samples.into_boxed_slice()),
+            format,
+        });
+
+        let frame = queue
+            .next_frame(2, 48_000)
+            .expect("last frame should be returned, not discarded");
+        // Final stereo frame — indices 94 and 95 of the flat sample array.
+        assert_eq!(frame, &[Sample(94), Sample(95)]);
     }
 
     #[test]

--- a/tests/audio_types.rs
+++ b/tests/audio_types.rs
@@ -116,6 +116,46 @@ fn test_sample_to_f32_typical_values() {
 }
 
 #[test]
+fn test_audio_format_duration_us_rounds_half_up() {
+    // 1 frame at 48 kHz is 20.833 µs — the implementation adds `rate / 2`
+    // before dividing by `rate` so that duration rounds to the nearest whole
+    // microsecond (21) instead of truncating to 20. This keeps duration_us
+    // consistent with the remainder-tracking cursor advance in synced_player.
+    let format = AudioFormat {
+        codec: Codec::Pcm,
+        sample_rate: 48_000,
+        channels: 1,
+        bit_depth: 24,
+        codec_header: None,
+    };
+    assert_eq!(
+        format.duration_us(1),
+        21,
+        "48 kHz / 1 frame should round to 21 µs"
+    );
+    // 1000 frames at 48 kHz is 20833.33 µs → rounds to 20833.
+    assert_eq!(format.duration_us(1000), 20_833);
+    // Exact divisions stay exact.
+    assert_eq!(format.duration_us(48_000), 1_000_000);
+}
+
+#[test]
+fn test_audio_format_duration_us_accounts_for_channels() {
+    // `num_samples` is the *total* interleaved sample count. Stereo halves
+    // the frame count, so duration should be half of what a mono format of
+    // the same rate reports.
+    let stereo = AudioFormat {
+        codec: Codec::Pcm,
+        sample_rate: 48_000,
+        channels: 2,
+        bit_depth: 24,
+        codec_header: None,
+    };
+    // 96 samples stereo = 48 frames at 48 kHz = 1000 µs exactly.
+    assert_eq!(stereo.duration_us(96), 1_000);
+}
+
+#[test]
 fn test_audio_format_equality() {
     let format1 = AudioFormat {
         codec: Codec::Pcm,

--- a/tests/binary_frames.rs
+++ b/tests/binary_frames.rs
@@ -197,6 +197,31 @@ fn test_visualizer_chunk_wrong_type() {
     assert!(result.is_err());
 }
 
+#[test]
+fn test_visualizer_chunk_minimum_valid() {
+    // Exactly 9 bytes — type byte + 8-byte timestamp with no FFT payload —
+    // is the smallest legal visualizer frame and must parse successfully.
+    // This is the lower bound of the length guard; a frame of exactly 9
+    // bytes is *valid*, not too-short.
+    let frame: Vec<u8> = vec![
+        0x10, // Type: visualizer
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x2A, // Timestamp: 42
+    ];
+    let chunk = VisualizerChunk::from_bytes(&frame).unwrap();
+    assert_eq!(chunk.timestamp, 42);
+    assert!(chunk.data.is_empty());
+}
+
+#[test]
+fn test_visualizer_chunk_too_short() {
+    // 8 bytes — type byte + partial timestamp — is one byte short of a
+    // valid frame and must be rejected. Paired with the 9-byte
+    // minimum-valid test above, these pin both sides of the length guard.
+    let frame: Vec<u8> = vec![0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+    let result = VisualizerChunk::from_bytes(&frame);
+    assert!(result.is_err());
+}
+
 // =============================================================================
 // Binary Frame Dispatch Tests
 // =============================================================================

--- a/tests/buffer_pool.rs
+++ b/tests/buffer_pool.rs
@@ -39,3 +39,29 @@ fn test_buffer_pool_fallback_allocation() {
     let buf3 = pool.get();
     assert_eq!(buf3.capacity(), 1024);
 }
+
+#[test]
+fn test_buffer_pool_put_actually_returns_buffer() {
+    // `put()` must deposit the buffer back into the pool so a later `get()`
+    // reuses it. A check on default-capacity buffers can't distinguish a
+    // reused buffer from a fresh `Vec::with_capacity(pool.capacity())`, so
+    // this test deposits a buffer whose capacity is *larger* than the pool's
+    // default — if it comes back from `get()`, the pool really did store it.
+    let pool = BufferPool::new(1, 1024);
+
+    // Drain the pre-allocated buffer so the pool is empty.
+    let _ = pool.get();
+
+    // Put a buffer with a distinctive (larger) capacity.
+    let oversized: Vec<Sample> = Vec::with_capacity(4096);
+    pool.put(oversized);
+
+    // Get should return the oversized buffer we just put back, NOT a freshly
+    // allocated 1024-capacity one.
+    let reused = pool.get();
+    assert!(
+        reused.capacity() >= 4096,
+        "expected put buffer to be returned (cap >= 4096), got {}",
+        reused.capacity()
+    );
+}

--- a/tests/protocol_client.rs
+++ b/tests/protocol_client.rs
@@ -512,6 +512,235 @@ async fn test_no_controller_when_role_not_declared() {
     );
 }
 
+/// Variant of [`start_test_server`] that drives the server side directly —
+/// exposes both the send half (for server-initiated messages) and the receive
+/// half (for client-sent messages).
+async fn start_test_server_with_sender() -> (
+    String,
+    tokio::sync::mpsc::UnboundedReceiver<String>,
+    tokio::sync::mpsc::UnboundedSender<WsMessage>,
+    tokio::task::JoinHandle<()>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let url = format!("ws://{}", addr);
+
+    let (client_tx, client_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (server_send_tx, mut server_send_rx) = tokio::sync::mpsc::unbounded_channel::<WsMessage>();
+
+    let handle = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut ws = accept_async(stream).await.unwrap();
+
+        // Drive handshake: consume client/hello, echo roles back.
+        let msg = ws.next().await.unwrap().unwrap();
+        let active_roles = if let WsMessage::Text(ref text) = msg {
+            match serde_json::from_str::<Message>(text).unwrap() {
+                Message::ClientHello(hello) => hello.supported_roles,
+                other => panic!("First message should be client/hello, got {:?}", other),
+            }
+        } else {
+            panic!("Expected text message for client/hello");
+        };
+        let server_hello = serde_json::to_string(&Message::ServerHello(
+            sendspin::protocol::messages::ServerHello {
+                server_id: "test-server".to_string(),
+                name: "Test Server".to_string(),
+                version: 1,
+                active_roles,
+                connection_reason: sendspin::protocol::messages::ConnectionReason::Playback,
+            },
+        ))
+        .unwrap();
+        ws.send(WsMessage::Text(server_hello)).await.unwrap();
+
+        // Fan in: forward client messages to `client_tx`, forward outgoing
+        // `server_send_rx` messages to the socket.
+        loop {
+            tokio::select! {
+                msg = ws.next() => {
+                    let Some(Ok(msg)) = msg else { break };
+                    let text = match msg {
+                        WsMessage::Text(text) => text,
+                        WsMessage::Close(_) => break,
+                        _ => continue,
+                    };
+                    if client_tx.send(text).is_err() { break }
+                }
+                outgoing = server_send_rx.recv() => {
+                    let Some(out) = outgoing else { break };
+                    if ws.send(out).await.is_err() { break }
+                }
+            }
+        }
+    });
+
+    (url, client_rx, server_send_tx, handle)
+}
+
+#[tokio::test]
+async fn test_clock_sync_getter_returns_shared_handle() {
+    // `clock_sync()` must return the *same* `Arc<Mutex<ClockSync>>` instance
+    // on every call — callers rely on shared state with the background time
+    // sync task. Two calls returning pointer-distinct handles would compile
+    // fine but silently break sync state sharing; `Arc::ptr_eq` pins this.
+    let (url, _rx, _handle) = start_test_server().await;
+    let client = ProtocolClientBuilder::builder()
+        .client_id("test-client".to_string())
+        .name("Test".to_string())
+        .build()
+        .connect(&url)
+        .await
+        .unwrap();
+
+    let a = client.clock_sync();
+    let b = client.clock_sync();
+    assert!(
+        std::sync::Arc::ptr_eq(&a, &b),
+        "clock_sync() must return the same shared handle on every call"
+    );
+}
+
+#[tokio::test]
+async fn test_message_router_forwards_binary_audio() {
+    // End-to-end: server sends a binary audio frame, it should land in
+    // `conn.audio`. Exercises the router's `WsMessage::Binary` arm, the
+    // audio-channel dispatch, and the `!audio_closed && send.is_err()`
+    // guard (which must still forward successfully when the channel is
+    // open). A regression anywhere along the path manifests as
+    // `conn.audio.recv()` timing out.
+    let (url, _rx, server_tx, _handle) = start_test_server_with_sender().await;
+    let client = ProtocolClientBuilder::builder()
+        .client_id("test-client".to_string())
+        .name("Test".to_string())
+        .player_v1_support(PlayerV1Support {
+            supported_formats: vec![AudioFormatSpec {
+                codec: "pcm".to_string(),
+                channels: 2,
+                sample_rate: 48000,
+                bit_depth: 24,
+            }],
+            buffer_capacity: 1024,
+            supported_commands: vec![],
+        })
+        .build()
+        .connect(&url)
+        .await
+        .unwrap();
+    let mut conn = client.split();
+
+    // Audio chunk: type 4, 8-byte big-endian timestamp, then payload.
+    let audio_frame: Vec<u8> = vec![
+        0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x2A, 0xDE, 0xAD,
+    ];
+    server_tx.send(WsMessage::Binary(audio_frame)).unwrap();
+
+    let chunk = tokio::time::timeout(std::time::Duration::from_secs(2), conn.audio.recv())
+        .await
+        .expect("timed out waiting for audio chunk")
+        .expect("audio channel closed");
+    assert_eq!(chunk.timestamp, 42);
+    assert_eq!(&*chunk.data, &[0xDE, 0xAD]);
+}
+
+#[tokio::test]
+async fn test_message_router_forwards_binary_artwork() {
+    // Mirror of the audio routing test for the artwork path (binary
+    // types 8-11). The artwork channel-dispatch and its
+    // `!artwork_closed && send.is_err()` guard are structurally distinct
+    // from the audio path — each channel has its own closed-flag and send
+    // wiring, so each needs its own end-to-end coverage.
+    let (url, _rx, server_tx, _handle) = start_test_server_with_sender().await;
+    let client = ProtocolClientBuilder::builder()
+        .client_id("test-client".to_string())
+        .name("Test".to_string())
+        .build()
+        .connect(&url)
+        .await
+        .unwrap();
+    let mut conn = client.split();
+
+    // Artwork channel 2: type 0x0A, 8-byte big-endian timestamp, then payload.
+    let artwork_frame: Vec<u8> = vec![
+        0x0A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x64, 0xFF, 0xD8, 0xFF, 0xE0,
+    ];
+    server_tx.send(WsMessage::Binary(artwork_frame)).unwrap();
+
+    let chunk = tokio::time::timeout(std::time::Duration::from_secs(2), conn.artwork.recv())
+        .await
+        .expect("timed out waiting for artwork chunk")
+        .expect("artwork channel closed");
+    assert_eq!(chunk.channel, 2);
+    assert_eq!(chunk.timestamp, 100);
+    assert_eq!(&*chunk.data, &[0xFF, 0xD8, 0xFF, 0xE0]);
+}
+
+#[tokio::test]
+async fn test_message_router_forwards_binary_visualizer() {
+    // Mirror of the audio routing test for the visualizer path (binary
+    // type 16 / 0x10). Like artwork, visualizer has its own
+    // channel-dispatch and `!visualizer_closed && send.is_err()` guard,
+    // independent of the audio and artwork paths.
+    let (url, _rx, server_tx, _handle) = start_test_server_with_sender().await;
+    let client = ProtocolClientBuilder::builder()
+        .client_id("test-client".to_string())
+        .name("Test".to_string())
+        .build()
+        .connect(&url)
+        .await
+        .unwrap();
+    let mut conn = client.split();
+
+    // Visualizer: type 0x10, 8-byte big-endian timestamp, then FFT data.
+    let vis_frame: Vec<u8> = vec![
+        0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC8, 0x01, 0x02, 0x03,
+    ];
+    server_tx.send(WsMessage::Binary(vis_frame)).unwrap();
+
+    let chunk = tokio::time::timeout(std::time::Duration::from_secs(2), conn.visualizer.recv())
+        .await
+        .expect("timed out waiting for visualizer chunk")
+        .expect("visualizer channel closed");
+    assert_eq!(chunk.timestamp, 200);
+    assert_eq!(&*chunk.data, &[0x01, 0x02, 0x03]);
+}
+
+#[tokio::test]
+async fn test_message_router_forwards_text_messages() {
+    // End-to-end: server sends a protocol text message, it should land in
+    // `conn.messages`. Exercises the router's `WsMessage::Text` arm, the
+    // JSON deserialization step, and the `!message_closed && send.is_err()`
+    // guard. A regression in any of those paths manifests as
+    // `conn.messages.recv()` timing out.
+    let (url, _rx, server_tx, _handle) = start_test_server_with_sender().await;
+    let client = ProtocolClientBuilder::builder()
+        .client_id("test-client".to_string())
+        .name("Test".to_string())
+        .build()
+        .connect(&url)
+        .await
+        .unwrap();
+    let mut conn = client.split();
+
+    let server_state = serde_json::to_string(&Message::ServerState(
+        sendspin::protocol::messages::ServerState {
+            metadata: None,
+            controller: None,
+        },
+    ))
+    .unwrap();
+    server_tx.send(WsMessage::Text(server_state)).unwrap();
+
+    let msg = tokio::time::timeout(std::time::Duration::from_secs(2), conn.messages.recv())
+        .await
+        .expect("timed out waiting for server message")
+        .expect("message channel closed");
+    match msg {
+        Message::ServerState(_) => {}
+        other => panic!("expected ServerState, got {other:?}"),
+    }
+}
+
 #[test]
 #[ignore] // Requires running server
 fn test_client_receives_stream_start() {


### PR DESCRIPTION
I was playing around with https://mutants.rs and found some test gaps. There are additional 'mutants' that we are not catching, even with these additional tests, but they are all either semantically equivalent or require a full "real audio device" integration style test, which we don't have yet.


Adds targeted tests across the audio pipeline and protocol client to pin behaviors that were previously untested — getter polarity, exact arithmetic, boundary conditions, and end-to-end routing paths:

- gain: unmuted getter, Debug field exposure, stereo buffer shorter than ramp
- buffer_pool: verify put() actually returns the buffer to the pool (capacity-witness)
- sync_correction: exact drop/insert interval values below and at the max-speed-correction cap
- audio_types: AudioFormat::duration_us rounding and channel accounting
- synced_player: adjacent-buffer dedup on reverse-order push, next_frame at the final-frame skip boundary, build() channels==0 guard
- binary_frames: VisualizerChunk 9-byte minimum-valid and 8-byte too-short boundary
- protocol_client: clock_sync() shared-handle identity; end-to-end routing for binary audio, artwork, visualizer, and text messages