### PR TITLE
fix: accept float values for TrackProgress numeric fields

### DIFF
--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -343,11 +343,66 @@ pub struct MetadataState {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TrackProgress {
     /// Current position in milliseconds
+    #[serde(deserialize_with = "deserialize_number_as_i64")]
     pub track_progress: i64,
     /// Total duration in milliseconds (0 for unknown/live streams)
+    #[serde(deserialize_with = "deserialize_number_as_i64")]
     pub track_duration: i64,
     /// Playback speed multiplier * 1000 (1000 = normal, 0 = paused)
+    #[serde(deserialize_with = "deserialize_number_as_i32")]
     pub playback_speed: i32,
+}
+
+/// Deserialize a JSON number (int or float) as i64
+fn deserialize_number_as_i64<'de, D>(deserializer: D) -> Result<i64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct NumberVisitor;
+    impl<'de> de::Visitor<'de> for NumberVisitor {
+        type Value = i64;
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a number (integer or float)")
+        }
+        fn visit_i64<E: de::Error>(self, v: i64) -> Result<i64, E> {
+            Ok(v)
+        }
+        fn visit_u64<E: de::Error>(self, v: u64) -> Result<i64, E> {
+            Ok(v as i64)
+        }
+        fn visit_f64<E: de::Error>(self, v: f64) -> Result<i64, E> {
+            Ok(v as i64)
+        }
+    }
+    deserializer.deserialize_any(NumberVisitor)
+}
+
+/// Deserialize a JSON number (int or float) as i32
+fn deserialize_number_as_i32<'de, D>(deserializer: D) -> Result<i32, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct NumberVisitor;
+    impl<'de> de::Visitor<'de> for NumberVisitor {
+        type Value = i32;
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a number (integer or float)")
+        }
+        fn visit_i64<E: de::Error>(self, v: i64) -> Result<i32, E> {
+            Ok(v as i32)
+        }
+        fn visit_u64<E: de::Error>(self, v: u64) -> Result<i32, E> {
+            Ok(v as i32)
+        }
+        fn visit_f64<E: de::Error>(self, v: f64) -> Result<i32, E> {
+            Ok(v as i32)
+        }
+    }
+    deserializer.deserialize_any(NumberVisitor)
 }
 
 /// Repeat mode

--- a/tests/protocol_messages.rs
+++ b/tests/protocol_messages.rs
@@ -3,7 +3,7 @@ use sendspin::protocol::messages::{
     ClientCommand, ClientGoodbye, ClientHello, ClientState, ClientSyncState, ClientTime,
     ConnectionReason, ControllerCommand, ControllerCommandType, DeviceInfo, GoodbyeReason,
     ImageFormat, Message, PlaybackState, PlayerCommandType, PlayerState, PlayerStateCommand,
-    PlayerV1Support, RepeatMode, ServerTime, StreamArtworkChannelConfig,
+    PlayerV1Support, RepeatMode, ServerTime, StreamArtworkChannelConfig, TrackProgress,
 };
 
 // =============================================================================
@@ -168,6 +168,38 @@ fn test_server_state_metadata_deserialization() {
         }
         _ => panic!("Expected ServerState"),
     }
+}
+
+#[test]
+fn test_track_progress_accepts_float_values() {
+    // Music Assistant sends track_progress, track_duration, and playback_speed
+    // as floats (e.g., 292333.0) instead of integers. Verify the custom
+    // deserializers accept them and truncate to the integer type.
+    let json = r#"{
+        "track_progress": 292333.0,
+        "track_duration": 180000.5,
+        "playback_speed": 1000.0
+    }"#;
+
+    let progress: TrackProgress = serde_json::from_str(json).unwrap();
+    assert_eq!(progress.track_progress, 292333);
+    assert_eq!(progress.track_duration, 180000);
+    assert_eq!(progress.playback_speed, 1000);
+}
+
+#[test]
+fn test_track_progress_still_accepts_integers() {
+    // Regression guard: integer values must continue to deserialize as before.
+    let json = r#"{
+        "track_progress": 60000,
+        "track_duration": 180000,
+        "playback_speed": 1000
+    }"#;
+
+    let progress: TrackProgress = serde_json::from_str(json).unwrap();
+    assert_eq!(progress.track_progress, 60000);
+    assert_eq!(progress.track_duration, 180000);
+    assert_eq!(progress.playback_speed, 1000);
 }
 
 #[test]


### PR DESCRIPTION
## Problem

 Music Assistant sends `track_progress`, `track_duration`, and `playback_speed` as JSON floats (e.g. `292333.0`) rather than integers. Because `TrackProgress` deserializes those fields as bare `i64` / `i32`, every
 `server/state` message that carries a `progress` payload fails to parse and
  the metadata is silently dropped.

  Symptom on the client side: track title/artist update on stream start but
  never again during playback, and any client that depends on `track_progress` for UI never sees a position.

## Fix

Custom serde deserializers that accept either integer or float JSON numbers and truncate floats to the destination integer type. The field types and public API are unchanged.

  The narrow scope is deliberate — only the three fields MA is known to send as floats. Other numeric fields keep their strict types so the protocol still fails loudly on unexpected shape changes elsewhere.

  ## Tests
  
  - `test_track_progress_accepts_float_values` — exercises the MA-style float payload.
  - `test_track_progress_still_accepts_integers` — guards the existing integer path.
  - `test_track_progress_still_accepts_integers` — guards the existing integer path.

  `cargo test --all-features --release`, `cargo fmt --check`, and `cargo clippy
  --all-targets --all-features --release -- -D warnings` are all clean against `main`.

 ## Context

  Caught while running a sendspin-rs–based client against Music Assistant; every progress update on a playlist track was getting silently dropped. Happy to  adjust scope or split the deserializer helpers into a shared module if you'd prefer.