### PR TITLE
feat!: add option to overwrite the default buffer size

### DIFF
--- a/examples/player.rs
+++ b/examples/player.rs
@@ -379,6 +379,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     device.as_ref().cloned(),
                                     100,
                                     false,
+                                    None,
                                 ) {
                                     Ok(player) => {
                                         println!("Synced audio output initialized");

--- a/src/audio/synced_player.rs
+++ b/src/audio/synced_player.rs
@@ -232,8 +232,9 @@ impl SyncedPlayer {
         device: Option<Device>,
         volume: u8,
         muted: bool,
+        buffer_size: Option<u32>,
     ) -> Result<Self, Error> {
-        Self::build(format, clock_sync, device, None, volume, muted)
+        Self::build(format, clock_sync, device, None, volume, muted, buffer_size)
     }
 
     /// Create a player with a process callback for post-gain audio processing.
@@ -271,9 +272,18 @@ impl SyncedPlayer {
         device: Option<Device>,
         volume: u8,
         muted: bool,
+        buffer_size: Option<u32>,
         callback: ProcessCallback,
     ) -> Result<Self, Error> {
-        Self::build(format, clock_sync, device, Some(callback), volume, muted)
+        Self::build(
+            format,
+            clock_sync,
+            device,
+            Some(callback),
+            volume,
+            muted,
+            buffer_size,
+        )
     }
 
     fn build(
@@ -283,6 +293,7 @@ impl SyncedPlayer {
         process_callback: Option<ProcessCallback>,
         volume: u8,
         muted: bool,
+        buffer_size: Option<u32>,
     ) -> Result<Self, Error> {
         if format.channels == 0 {
             return Err(Error::Output("channels must be > 0".to_string()));
@@ -298,7 +309,10 @@ impl SyncedPlayer {
         let config = StreamConfig {
             channels: format.channels as u16,
             sample_rate: cpal::SampleRate::from(format.sample_rate),
-            buffer_size: cpal::BufferSize::Default,
+            buffer_size: match buffer_size {
+                Some(frames) => cpal::BufferSize::Fixed(frames),
+                None => cpal::BufferSize::Default,
+            },
         };
 
         let queue = Arc::new(Mutex::new(PlaybackQueue::new()));

--- a/src/audio/synced_player.rs
+++ b/src/audio/synced_player.rs
@@ -226,6 +226,7 @@ impl SyncedPlayer {
     /// The player starts at `volume` (0-100) and `muted` state. These are
     /// applied immediately — the first audio callback uses the correct gain
     /// with no ramp from a default value.
+    /// The `buffer_size` overrides cpal audio device default. If not set, the default buffer size is used.
     pub fn new(
         format: AudioFormat,
         clock_sync: Arc<Mutex<ClockSync>>,
@@ -260,7 +261,7 @@ impl SyncedPlayer {
     /// let clock_sync = Arc::new(Mutex::new(ClockSync::new(Arc::new(DefaultClock::new()))));
     /// let player = SyncedPlayer::with_process_callback(
     ///     format, clock_sync, None,
-    ///     100, false,
+    ///     100, false, None,
     ///     Box::new(|data| { /* e.g. feed a VU meter or visualizer */ }),
     /// )?;
     /// # Ok(())


### PR DESCRIPTION
on some devices the default buffer size is to small (e.g. raspberry pi zero) so it needs to be overwritten. 

This allows setting the buffer size explicitly. 

This is a breaking change as the public api of `SyncedPlayer::new` and `with_process_callback` now need the `buffer_size` argument. 