### PR TITLE
fix: pr#48 left synced_player uncompilable

### DIFF
--- a/src/audio/synced_player.rs
+++ b/src/audio/synced_player.rs
@@ -686,7 +686,7 @@ mod tests {
             codec_header: None,
         };
         let clock_sync = Arc::new(Mutex::new(ClockSync::new(Arc::new(DefaultClock::new()))));
-        let result = SyncedPlayer::new(format, clock_sync, None, 100, false);
+        let result = SyncedPlayer::new(format, clock_sync, None, 100, false, None);
         let err = match result {
             Ok(_) => panic!("channels=0 should be rejected"),
             Err(e) => e,


### PR DESCRIPTION
We missed a place to update the newly required buffer size from #48. Quick fix.