### PR TITLE
feat: Add external source API

### DIFF
--- a/src/audio/synced_player.rs
+++ b/src/audio/synced_player.rs
@@ -385,6 +385,19 @@ impl SyncedPlayer {
         self.queue.lock().clear();
     }
 
+    /// Release the underlying audio output device.
+    ///
+    /// Consuming the player drops its active `cpal::Stream`, allowing another
+    /// local source to open the same device. Use this before advertising
+    /// `state: "external_source"`.
+    ///
+    /// The returned [`GainControl`] preserves Sendspin's software volume/mute
+    /// state across the handoff. It does not reflect hardware or OS mixer
+    /// changes made by the external source.
+    pub fn release_audio_device(self) -> GainControl {
+        self.gain
+    }
+
     /// Return the configured audio format.
     pub fn format(&self) -> &AudioFormat {
         &self.format

--- a/src/protocol/client.rs
+++ b/src/protocol/client.rs
@@ -3,9 +3,10 @@
 
 use crate::error::Error;
 use crate::protocol::messages::{
-    ArtworkFormatRequest, ClientCommand, ClientGoodbye, ClientHello, ClientState, ClientTime,
-    ControllerCommand, ControllerCommandType, GoodbyeReason, Message, PlayerFormatRequest,
-    RepeatMode, ServerHello, StreamEnd, StreamRequestFormat, StreamStart,
+    ArtworkFormatRequest, ClientCommand, ClientGoodbye, ClientHello, ClientState, ClientSyncState,
+    ClientTime, ControllerCommand, ControllerCommandType, GoodbyeReason, Message,
+    PlayerFormatRequest, PlayerState, RepeatMode, ServerHello, StreamEnd, StreamRequestFormat,
+    StreamStart,
 };
 use crate::sync::raw_clock::Clock;
 use crate::sync::ClockSync;
@@ -193,6 +194,37 @@ impl WsSender {
         ack_rx
             .await
             .map_err(|_| Error::WebSocket("connection closed".to_string()))?
+    }
+
+    /// Send a top-level client synchronization state update.
+    pub async fn send_sync_state(&self, state: ClientSyncState) -> Result<(), Error> {
+        self.send_message(Message::ClientState(ClientState {
+            state: Some(state),
+            player: None,
+        }))
+        .await
+    }
+
+    /// Tell the server this client is temporarily owned by another audio source.
+    ///
+    /// Release any Sendspin-owned output first so the external source can open
+    /// the device without racing this client's audio stream.
+    pub async fn enter_external_source(&self) -> Result<(), Error> {
+        self.send_sync_state(ClientSyncState::ExternalSource).await
+    }
+
+    /// Tell the server this client is ready for synchronized playback again.
+    ///
+    /// Include player state when volume, mute, or static delay may have changed
+    /// while the external source owned the device. Hardware/OS mixer changes
+    /// must be read through platform APIs; this library only tracks its own
+    /// software [`GainControl`](crate::audio::GainControl).
+    pub async fn exit_external_source(&self, player: Option<PlayerState>) -> Result<(), Error> {
+        self.send_message(Message::ClientState(ClientState {
+            state: Some(ClientSyncState::Synchronized),
+            player,
+        }))
+        .await
     }
 
     /// Request a change to the active stream format.
@@ -630,6 +662,18 @@ impl Drop for ConnectionGuard {
     }
 }
 
+impl Connection {
+    /// See [`WsSender::enter_external_source`].
+    pub async fn enter_external_source(&self) -> Result<(), Error> {
+        self.sender.enter_external_source().await
+    }
+
+    /// See [`WsSender::exit_external_source`].
+    pub async fn exit_external_source(&self, player: Option<PlayerState>) -> Result<(), Error> {
+        self.sender.exit_external_source(player).await
+    }
+}
+
 impl ProtocolClient {
     /// Connect to Sendspin server
     pub(crate) async fn connect<R>(
@@ -942,6 +986,26 @@ impl ProtocolClient {
     /// and aborts background tasks.
     pub async fn disconnect(self, reason: GoodbyeReason) -> Result<(), Error> {
         self.guard.disconnect(reason).await
+    }
+
+    /// See [`WsSender::enter_external_source`].
+    pub async fn enter_external_source(&self) -> Result<(), Error> {
+        WsSender {
+            tx: self.out_tx.clone(),
+            stream_state: Arc::clone(&self.stream_state),
+        }
+        .enter_external_source()
+        .await
+    }
+
+    /// See [`WsSender::exit_external_source`].
+    pub async fn exit_external_source(&self, player: Option<PlayerState>) -> Result<(), Error> {
+        WsSender {
+            tx: self.out_tx.clone(),
+            stream_state: Arc::clone(&self.stream_state),
+        }
+        .exit_external_source(player)
+        .await
     }
 
     /// Get reference to clock sync

--- a/src/protocol/client_builder.rs
+++ b/src/protocol/client_builder.rs
@@ -26,6 +26,7 @@ pub(crate) struct ProtocolClientBuilderRaw {
     player_v1_support: Option<PlayerV1Support>,
     artwork_v1_support: Option<ArtworkV1Support>,
     visualizer_v1_support: Option<VisualizerV1Support>,
+    initial_sync_state: ClientSyncState,
     initial_player_state: Option<PlayerState>,
     metadata: bool,
     controller: bool,
@@ -92,6 +93,7 @@ impl From<ProtocolClientBuilderRaw> for ProtocolClientBuilder {
             clock: Arc::new(DefaultClock::new()),
             artwork_v1_support: raw.artwork_v1_support,
             visualizer_v1_support: raw.visualizer_v1_support,
+            initial_sync_state: raw.initial_sync_state,
             initial_player_state: raw.initial_player_state,
         }
     }
@@ -115,6 +117,9 @@ pub struct ProtocolClientBuilderFields {
     artwork_v1_support: Option<ArtworkV1Support>,
     #[builder(default = None, setter(transform = |x: VisualizerV1Support| Some(x)))]
     visualizer_v1_support: Option<VisualizerV1Support>,
+    /// Initial top-level synchronization state sent in the first `client/state`.
+    #[builder(default = ClientSyncState::Synchronized)]
+    initial_sync_state: ClientSyncState,
     #[builder(default = None, setter(transform = |x: PlayerState| Some(x)))]
     initial_player_state: Option<PlayerState>,
     #[builder(default = false, setter(transform = || true))]
@@ -134,6 +139,7 @@ impl From<ProtocolClientBuilderFields> for ProtocolClientBuilder {
             player_v1_support: fields.player_v1_support,
             artwork_v1_support: fields.artwork_v1_support,
             visualizer_v1_support: fields.visualizer_v1_support,
+            initial_sync_state: fields.initial_sync_state,
             initial_player_state: fields.initial_player_state,
             metadata: fields.metadata,
             controller: fields.controller,
@@ -154,6 +160,7 @@ pub struct ProtocolClientBuilder {
     player_v1_support: Option<PlayerV1Support>,
     artwork_v1_support: Option<ArtworkV1Support>,
     visualizer_v1_support: Option<VisualizerV1Support>,
+    initial_sync_state: ClientSyncState,
     initial_player_state: Option<PlayerState>,
     clock: Arc<dyn Clock>,
 }
@@ -240,7 +247,7 @@ impl ProtocolClientBuilder {
         };
 
         let initial_state = ClientState {
-            state: Some(ClientSyncState::Synchronized),
+            state: Some(self.initial_sync_state),
             player: self.initial_player_state,
         };
 

--- a/tests/protocol_client.rs
+++ b/tests/protocol_client.rs
@@ -232,6 +232,69 @@ async fn test_connect_without_player_state_sends_state_without_player() {
 }
 
 #[tokio::test]
+async fn test_connect_can_send_initial_external_source_state() {
+    let (url, mut rx, _handle) = start_test_server().await;
+
+    let builder = ProtocolClientBuilder::builder()
+        .client_id("test-client".to_string())
+        .name("Test".to_string())
+        .initial_sync_state(ClientSyncState::ExternalSource)
+        .build();
+
+    let _client = builder.connect(&url).await.unwrap();
+
+    let first_msg = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+        .await
+        .expect("timed out waiting for message")
+        .expect("channel closed");
+
+    let parsed: Message = serde_json::from_str(&first_msg).unwrap();
+    match parsed {
+        Message::ClientState(cs) => {
+            assert_eq!(cs.state, Some(ClientSyncState::ExternalSource));
+            assert!(cs.player.is_none(), "expected no player state");
+        }
+        other => panic!("expected ClientState, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_connect_initial_external_source_preserves_player_state() {
+    let (url, mut rx, _handle) = start_test_server().await;
+
+    let builder = ProtocolClientBuilder::builder()
+        .client_id("test-client".to_string())
+        .name("Test".to_string())
+        .initial_sync_state(ClientSyncState::ExternalSource)
+        .initial_player_state(PlayerState {
+            volume: Some(23),
+            muted: Some(true),
+            static_delay_ms: Some(250),
+            supported_commands: None,
+        })
+        .build();
+
+    let _client = builder.connect(&url).await.unwrap();
+
+    let first_msg = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+        .await
+        .expect("timed out waiting for message")
+        .expect("channel closed");
+
+    let parsed: Message = serde_json::from_str(&first_msg).unwrap();
+    match parsed {
+        Message::ClientState(cs) => {
+            assert_eq!(cs.state, Some(ClientSyncState::ExternalSource));
+            let player = cs.player.expect("expected player state");
+            assert_eq!(player.volume, Some(23));
+            assert_eq!(player.muted, Some(true));
+            assert_eq!(player.static_delay_ms, Some(250));
+        }
+        other => panic!("expected ClientState, got {:?}", other),
+    }
+}
+
+#[tokio::test]
 async fn test_disconnect_sends_goodbye() {
     let (url, mut rx, _handle) = start_test_server().await;
 
@@ -632,6 +695,93 @@ async fn next_client_command(
             return cmd;
         }
     }
+}
+
+async fn next_client_state(
+    rx: &mut tokio::sync::mpsc::UnboundedReceiver<String>,
+) -> sendspin::protocol::messages::ClientState {
+    loop {
+        let msg_text = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .await
+            .expect("timed out waiting for message")
+            .expect("channel closed");
+
+        let parsed: Message = serde_json::from_str(&msg_text).unwrap();
+        if let Message::ClientState(state) = parsed {
+            return state;
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_enter_external_source_sends_external_source_state() {
+    let (url, mut rx, _handle) = start_test_server().await;
+    let client = ProtocolClientBuilder::builder()
+        .client_id("test-client".to_string())
+        .name("Test".to_string())
+        .build()
+        .connect(&url)
+        .await
+        .unwrap();
+
+    let initial = next_client_state(&mut rx).await;
+    assert_eq!(initial.state, Some(ClientSyncState::Synchronized));
+
+    client.enter_external_source().await.unwrap();
+
+    let state = next_client_state(&mut rx).await;
+    assert_eq!(state.state, Some(ClientSyncState::ExternalSource));
+    assert!(state.player.is_none());
+}
+
+#[tokio::test]
+async fn test_exit_external_source_sends_synchronized_state() {
+    let (url, mut rx, _handle) = start_test_server().await;
+    let client = ProtocolClientBuilder::builder()
+        .client_id("test-client".to_string())
+        .name("Test".to_string())
+        .build()
+        .connect(&url)
+        .await
+        .unwrap();
+
+    let initial = next_client_state(&mut rx).await;
+    assert_eq!(initial.state, Some(ClientSyncState::Synchronized));
+
+    client.exit_external_source(None).await.unwrap();
+
+    let state = next_client_state(&mut rx).await;
+    assert_eq!(state.state, Some(ClientSyncState::Synchronized));
+    assert!(state.player.is_none());
+}
+
+#[tokio::test]
+async fn test_exit_external_source_sends_full_player_state() {
+    let (url, mut rx, _handle) = start_test_server().await;
+    let client = ProtocolClientBuilder::builder()
+        .client_id("test-client".to_string())
+        .name("Test".to_string())
+        .build()
+        .connect(&url)
+        .await
+        .unwrap();
+
+    let _initial = next_client_state(&mut rx).await;
+
+    client
+        .exit_external_source(Some(PlayerState {
+            volume: Some(42),
+            muted: Some(true),
+            ..Default::default()
+        }))
+        .await
+        .unwrap();
+
+    let state = next_client_state(&mut rx).await;
+    assert_eq!(state.state, Some(ClientSyncState::Synchronized));
+    let player = state.player.expect("player state should be present");
+    assert_eq!(player.volume, Some(42));
+    assert_eq!(player.muted, Some(true));
 }
 
 // Macro to generate tests for simple controller commands (no parameters).


### PR DESCRIPTION
- ClientSyncState::ExternalSource support for spec's state: "external_source"
- enter_external_source / exit_external_source on WsSender, Connection, ProtocolClient
- Builder initial_sync_state field for clients booting into external source
- SyncedPlayer::release_audio_device to free the cpal device, preserving GainControl
- Tests for initial state, enter, and exit (with/without player state)

Closes #54 