### PR TITLE
feat: add mac_address field to DeviceInfo per spec PR #87

### DIFF
--- a/src/protocol/client_builder.rs
+++ b/src/protocol/client_builder.rs
@@ -23,6 +23,7 @@ pub(crate) struct ProtocolClientBuilderRaw {
     product_name: Option<String>,
     manufacturer: Option<String>,
     software_version: Option<String>,
+    mac_address: Option<String>,
     player_v1_support: Option<PlayerV1Support>,
     artwork_v1_support: Option<ArtworkV1Support>,
     visualizer_v1_support: Option<VisualizerV1Support>,
@@ -87,6 +88,7 @@ impl From<ProtocolClientBuilderRaw> for ProtocolClientBuilder {
             product_name: raw.product_name,
             manufacturer: raw.manufacturer,
             software_version: raw.software_version,
+            mac_address: raw.mac_address,
             supported_roles,
             player_v1_support,
             clock: Arc::new(DefaultClock::new()),
@@ -109,6 +111,8 @@ pub struct ProtocolClientBuilderFields {
     manufacturer: Option<String>,
     #[builder(default = None)]
     software_version: Option<String>,
+    #[builder(default = None)]
+    mac_address: Option<String>,
     #[builder(default = None, setter(transform = |x: PlayerV1Support| Some(x)))]
     player_v1_support: Option<PlayerV1Support>,
     #[builder(default = None, setter(transform = |x: ArtworkV1Support| Some(x)))]
@@ -131,6 +135,7 @@ impl From<ProtocolClientBuilderFields> for ProtocolClientBuilder {
             product_name: fields.product_name,
             manufacturer: fields.manufacturer,
             software_version: fields.software_version,
+            mac_address: fields.mac_address,
             player_v1_support: fields.player_v1_support,
             artwork_v1_support: fields.artwork_v1_support,
             visualizer_v1_support: fields.visualizer_v1_support,
@@ -150,6 +155,7 @@ pub struct ProtocolClientBuilder {
     product_name: Option<String>,
     manufacturer: Option<String>,
     software_version: Option<String>,
+    mac_address: Option<String>,
     supported_roles: Vec<String>,
     player_v1_support: Option<PlayerV1Support>,
     artwork_v1_support: Option<ArtworkV1Support>,
@@ -233,6 +239,7 @@ impl ProtocolClientBuilder {
                 product_name: self.product_name,
                 manufacturer: Some(self.manufacturer.unwrap_or_else(|| "Sendspin".to_string())),
                 software_version: self.software_version,
+                mac_address: self.mac_address,
             }),
             player_v1_support: self.player_v1_support,
             artwork_v1_support: self.artwork_v1_support,

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -115,6 +115,9 @@ pub struct DeviceInfo {
     /// Software version string
     #[serde(skip_serializing_if = "Option::is_none")]
     pub software_version: Option<String>,
+    /// MAC address of the network interface the connection is opened on, in lowercase colon-separated form (e.g., `aa:bb:cc:dd:ee:ff`)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mac_address: Option<String>,
 }
 
 /// Player@v1 capabilities

--- a/tests/protocol_messages.rs
+++ b/tests/protocol_messages.rs
@@ -21,6 +21,7 @@ fn test_client_hello_serialization() {
             product_name: Some("Sendspin-RS Player".to_string()),
             manufacturer: Some("Sendspin".to_string()),
             software_version: Some("0.1.0".to_string()),
+            mac_address: None,
         }),
         player_v1_support: Some(PlayerV1Support {
             supported_formats: vec![AudioFormatSpec {


### PR DESCRIPTION
Implements the optional `mac_address` field on `device_info` in `client/hello` as merged in [Sendspin/spec#87](https://github.com/Sendspin/spec/pull/87). 