### PR TITLE
feat!: Align to sendspin spec for sync state

### DIFF
--- a/src/protocol/client.rs
+++ b/src/protocol/client.rs
@@ -213,7 +213,8 @@ impl WsSender {
         self.send_sync_state(ClientSyncState::ExternalSource).await
     }
 
-    /// Tell the server this client is ready for synchronized playback again.
+    /// Tell the server this client's clock filter has converged enough to resume
+    /// synchronized playback scheduling.
     ///
     /// Include player state when volume, mute, or static delay may have changed
     /// while the external source owned the device. Hardware/OS mixer changes

--- a/src/protocol/client_builder.rs
+++ b/src/protocol/client_builder.rs
@@ -121,7 +121,8 @@ pub struct ProtocolClientBuilderFields {
     artwork_v1_support: Option<ArtworkV1Support>,
     #[builder(default = None, setter(transform = |x: VisualizerV1Support| Some(x)))]
     visualizer_v1_support: Option<VisualizerV1Support>,
-    /// Initial top-level synchronization state sent in the first `client/state`.
+    /// Initial top-level operational state sent in the first `client/state`.
+    /// [`ClientSyncState::ExternalSource`] when another source owns playback.
     #[builder(default = ClientSyncState::Synchronized)]
     initial_sync_state: ClientSyncState,
     #[builder(default = None, setter(transform = |x: PlayerState| Some(x)))]

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -288,17 +288,12 @@ pub enum PlayerStateCommand {
     SetStaticDelay,
 }
 
-/// Client synchronization state (top-level in client/state)
+/// Client operational state (top-level in client/state).
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ClientSyncState {
-    /// Client's clock is synchronized with the server; ready to receive
-    /// timestamped binary data.
+    /// Client's clock filter has converged enough to begin scheduling playback.
     Synchronized,
-    /// Client's clock is not yet synchronized with the server. This is the
-    /// client's initial state until clock synchronization is established. The
-    /// server does not send binary data to a client in this state.
-    NotSynchronized,
     /// Client is in use by an external system (e.g., different audio source, HDMI input)
     /// and is not currently participating in Sendspin playback with this server.
     ExternalSource,

--- a/tests/protocol_messages.rs
+++ b/tests/protocol_messages.rs
@@ -102,19 +102,6 @@ fn test_client_state_serialization() {
 }
 
 #[test]
-fn test_client_sync_state_not_synchronized() {
-    let state = ClientState {
-        state: Some(ClientSyncState::NotSynchronized),
-        player: None,
-    };
-
-    let message = Message::ClientState(state);
-    let json = serde_json::to_string(&message).unwrap();
-
-    assert!(json.contains("\"state\":\"not_synchronized\""));
-}
-
-#[test]
 fn test_client_sync_state_external_source() {
     let state = ClientState {
         state: Some(ClientSyncState::ExternalSource),


### PR DESCRIPTION
We no longer report error or not_synchronized, as per https://github.com/Sendspin/spec/pull/102