### PR TITLE
Add repeat/shuffle to ControllerState; deprecate on MetadataState (#66)

### DIFF
--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -340,9 +340,21 @@ pub struct MetadataState {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub progress: Option<TrackProgress>,
     /// Repeat mode
+    ///
+    /// Deprecated: the spec moved `repeat` to the controller `server/state`
+    /// object. Prefer [`ControllerState::repeat`] instead. This field is kept
+    /// only to parse the legacy dual-emit and will be removed in a future
+    /// release.
+    #[deprecated(since = "0.3.0", note = "use ControllerState::repeat instead")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub repeat: Option<RepeatMode>,
     /// Shuffle state
+    ///
+    /// Deprecated: the spec moved `shuffle` to the controller `server/state`
+    /// object. Prefer [`ControllerState::shuffle`] instead. This field is kept
+    /// only to parse the legacy dual-emit and will be removed in a future
+    /// release.
+    #[deprecated(since = "0.3.0", note = "use ControllerState::shuffle instead")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shuffle: Option<bool>,
 }
@@ -379,6 +391,12 @@ pub struct ControllerState {
     pub volume: u8,
     /// Whether audio is muted
     pub muted: bool,
+    /// Repeat mode
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repeat: Option<RepeatMode>,
+    /// Shuffle state
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shuffle: Option<bool>,
 }
 
 // =============================================================================

--- a/tests/protocol_messages.rs
+++ b/tests/protocol_messages.rs
@@ -115,6 +115,7 @@ fn test_client_sync_state_external_source() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn test_server_state_metadata_deserialization() {
     let json = r#"{
         "type": "server/state",
@@ -169,7 +170,9 @@ fn test_server_state_controller_deserialization() {
             "controller": {
                 "supported_commands": ["play", "next", "previous", "volume", "mute"],
                 "volume": 75,
-                "muted": false
+                "muted": false,
+                "repeat": "all",
+                "shuffle": true
             }
         }
     }"#;
@@ -181,6 +184,8 @@ fn test_server_state_controller_deserialization() {
             let controller = state.controller.expect("Expected controller");
             assert_eq!(controller.volume, 75);
             assert!(!controller.muted);
+            assert_eq!(controller.repeat, Some(RepeatMode::All));
+            assert_eq!(controller.shuffle, Some(true));
             assert!(controller.supported_commands.contains(&"play".to_string()));
             assert!(controller
                 .supported_commands


### PR DESCRIPTION
The spec moved `repeat`/`shuffle` from the metadata object into the controller `server/state` object. Add `repeat` (Option<RepeatMode>) and `shuffle` (Option<bool>) to ControllerState so controller-only clients can surface them, and mark the legacy MetadataState fields as `#[deprecated(since = "0.3.0")]` with a migration note pointing at ControllerState.

Resolves #66.