### PR TITLE
chore: bump dependencies to latest stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ native-tls = [
 
 [dependencies]
 # Async runtime
-tokio = { version = "1.40", features = ["full"] }
-tokio-tungstenite = "0.24"
+tokio = { version = "1.52", features = ["full"] }
+tokio-tungstenite = "0.29"
 tokio-native-tls = { version = "0.3", optional = true }
 native-tls = { version = "0.2", optional = true }
 futures-util = "0.3"
@@ -28,14 +28,14 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # Error handling
-thiserror = "1.0"
+thiserror = "2.0"
 
 # Utilities
 log = "0.4"
-uuid = { version = "1.10", features = ["v4", "serde"] }
+uuid = { version = "1.23", features = ["v4", "serde"] }
 
 # Audio output
-cpal = "0.17"
+cpal = "0.18"
 
 # Concurrency
 crossbeam = "0.8"
@@ -50,8 +50,8 @@ libc = "0.2"
 [dev-dependencies]
 tokio-test = "0.4"
 env_logger = "0.11"
-clap = { version = "4.5", features = ["derive"] }
-mdns-sd = "0.11"
+clap = { version = "4.6", features = ["derive"] }
+mdns-sd = "0.20"
 
 [profile.release]
 opt-level = 3

--- a/src/audio/synced_player.rs
+++ b/src/audio/synced_player.rs
@@ -533,7 +533,7 @@ impl SyncedPlayer {
         macro_rules! output_stream {
             ($sample:ty) => {
                 device.build_output_stream(
-                    &stream_config,
+                    stream_config,
                     move |data: &mut [$sample], info: &cpal::OutputCallbackInfo| {
                     let mut process_output = |data: &mut [$sample], buffer: &mut Vec<f32>| {
                         if let Some(ref mut cb) = cb_config.process_callback {
@@ -581,10 +581,7 @@ impl SyncedPlayer {
 
                     let callback_instant = Instant::now();
                     let ts = info.timestamp();
-                    let playback_delta = ts
-                        .playback
-                        .duration_since(&ts.callback)
-                        .unwrap_or(Duration::ZERO);
+                    let playback_delta = ts.playback.duration_since(ts.callback);
                     let playback_instant = callback_instant + playback_delta;
 
                     // try_lock: skip sync if contended rather than blocking

--- a/src/protocol/client.rs
+++ b/src/protocol/client.rs
@@ -77,7 +77,7 @@ where
 {
     let goodbye = Message::ClientGoodbye(ClientGoodbye { reason });
     let json = serde_json::to_string(&goodbye).map_err(|e| Error::Protocol(e.to_string()))?;
-    sink.send(WsMessage::Text(json))
+    sink.send(WsMessage::Text(json.into()))
         .await
         .map_err(|e| Error::WebSocket(e.to_string()))?;
     sink.close()
@@ -184,7 +184,7 @@ impl WsSender {
         let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
         self.tx
             .send(WriteCommand::Send {
-                msg: WsMessage::Text(json),
+                msg: WsMessage::Text(json.into()),
                 ack: ack_tx,
             })
             .map_err(|_| Error::WebSocket("connection closed".to_string()))?;
@@ -715,7 +715,7 @@ impl ProtocolClient {
             serde_json::to_string(&hello_msg).map_err(|e| Error::Protocol(e.to_string()))?;
         log::debug!("Sending client/hello: {}", hello_json);
         write
-            .send(WsMessage::Text(hello_json))
+            .send(WsMessage::Text(hello_json.into()))
             .await
             .map_err(|e| Error::WebSocket(e.to_string()))?;
 
@@ -775,7 +775,7 @@ impl ProtocolClient {
             serde_json::to_string(&state_msg).map_err(|e| Error::Protocol(e.to_string()))?;
         log::debug!("Sending initial client/state: {}", state_json);
         write
-            .send(WsMessage::Text(state_json))
+            .send(WsMessage::Text(state_json.into()))
             .await
             .map_err(|e| Error::WebSocket(e.to_string()))?;
 

--- a/tests/protocol_client.rs
+++ b/tests/protocol_client.rs
@@ -50,7 +50,7 @@ async fn start_test_server() -> (
             },
         ))
         .unwrap();
-        ws.send(WsMessage::Text(server_hello)).await.unwrap();
+        ws.send(WsMessage::Text(server_hello.into())).await.unwrap();
 
         // Forward all subsequent messages to the channel
         while let Some(Ok(msg)) = ws.next().await {
@@ -59,7 +59,7 @@ async fn start_test_server() -> (
                 WsMessage::Close(_) => break,
                 _ => continue,
             };
-            if tx.send(text).is_err() {
+            if tx.send(text.to_string()).is_err() {
                 break;
             }
         }
@@ -70,7 +70,7 @@ async fn start_test_server() -> (
 
 /// Serialize a protocol message into a WebSocket text frame.
 fn text_message(msg: &Message) -> WsMessage {
-    WsMessage::Text(serde_json::to_string(msg).unwrap())
+    WsMessage::Text(serde_json::to_string(msg).unwrap().into())
 }
 
 /// A server→client `stream/start` that starts a player stream.
@@ -913,7 +913,7 @@ async fn start_test_server_with_roles(
             },
         ))
         .unwrap();
-        ws.send(WsMessage::Text(server_hello)).await.unwrap();
+        ws.send(WsMessage::Text(server_hello.into())).await.unwrap();
 
         while let Some(Ok(msg)) = ws.next().await {
             let text = match msg {
@@ -921,7 +921,7 @@ async fn start_test_server_with_roles(
                 WsMessage::Close(_) => break,
                 _ => continue,
             };
-            if tx.send(text).is_err() {
+            if tx.send(text.to_string()).is_err() {
                 break;
             }
         }
@@ -1027,7 +1027,7 @@ async fn start_test_server_with_sender() -> (
             },
         ))
         .unwrap();
-        ws.send(WsMessage::Text(server_hello)).await.unwrap();
+        ws.send(WsMessage::Text(server_hello.into())).await.unwrap();
 
         // Fan in: forward client messages to `client_tx`, forward outgoing
         // `server_send_rx` messages to the socket.
@@ -1040,7 +1040,7 @@ async fn start_test_server_with_sender() -> (
                         WsMessage::Close(_) => break,
                         _ => continue,
                     };
-                    if client_tx.send(text).is_err() { break }
+                    if client_tx.send(text.to_string()).is_err() { break }
                 }
                 outgoing = server_send_rx.recv() => {
                     let Some(out) = outgoing else { break };
@@ -1103,7 +1103,9 @@ async fn test_message_router_forwards_binary_audio() {
     let audio_frame: Vec<u8> = vec![
         0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x2A, 0xDE, 0xAD,
     ];
-    server_tx.send(WsMessage::Binary(audio_frame)).unwrap();
+    server_tx
+        .send(WsMessage::Binary(audio_frame.into()))
+        .unwrap();
 
     let chunk = tokio::time::timeout(std::time::Duration::from_secs(2), conn.audio.recv())
         .await
@@ -1131,7 +1133,9 @@ async fn test_message_router_forwards_binary_artwork() {
     let artwork_frame: Vec<u8> = vec![
         0x0A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x64, 0xFF, 0xD8, 0xFF, 0xE0,
     ];
-    server_tx.send(WsMessage::Binary(artwork_frame)).unwrap();
+    server_tx
+        .send(WsMessage::Binary(artwork_frame.into()))
+        .unwrap();
 
     let chunk = tokio::time::timeout(std::time::Duration::from_secs(2), conn.artwork.recv())
         .await
@@ -1159,7 +1163,7 @@ async fn test_message_router_forwards_binary_visualizer() {
     let vis_frame: Vec<u8> = vec![
         0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC8, 0x01, 0x02, 0x03,
     ];
-    server_tx.send(WsMessage::Binary(vis_frame)).unwrap();
+    server_tx.send(WsMessage::Binary(vis_frame.into())).unwrap();
 
     let chunk = tokio::time::timeout(std::time::Duration::from_secs(2), conn.visualizer.recv())
         .await
@@ -1189,7 +1193,9 @@ async fn test_message_router_forwards_text_messages() {
         },
     ))
     .unwrap();
-    server_tx.send(WsMessage::Text(server_state)).unwrap();
+    server_tx
+        .send(WsMessage::Text(server_state.into()))
+        .unwrap();
 
     let msg = tokio::time::timeout(std::time::Duration::from_secs(2), conn.messages.recv())
         .await
@@ -1299,7 +1305,7 @@ async fn test_peer_close_midstream_ends_stream_and_fails_sends() {
             },
         ))
         .unwrap();
-        ws.send(WsMessage::Text(hello)).await.unwrap();
+        ws.send(WsMessage::Text(hello.into())).await.unwrap();
         let _ = ws.next().await; // initial client/state
         ws.close(None).await.unwrap();
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;

--- a/tests/protocol_listener.rs
+++ b/tests/protocol_listener.rs
@@ -48,7 +48,7 @@ where
     }))
     .unwrap();
     write
-        .send(WsMessage::Text(server_hello))
+        .send(WsMessage::Text(server_hello.into()))
         .await
         .expect("send server/hello");
 
@@ -60,7 +60,7 @@ where
                 WsMessage::Close(_) => break,
                 _ => continue,
             };
-            if tx.send(text).is_err() {
+            if tx.send(text.to_string()).is_err() {
                 break;
             }
         }


### PR DESCRIPTION
Major bumps:
- tokio-tungstenite 0.24 -> 0.29
- thiserror 1.0 -> 2.0
- cpal 0.17 -> 0.18
- mdns-sd 0.11 -> 0.20

Minor/floor refreshes for tokio, uuid, clap, and the remaining crates.

API adjustments required by the majors:
- cpal 0.18: build_output_stream takes StreamConfig by value; StreamInstant::duration_since takes self by value and returns Duration directly.
- tungstenite 0.29: Message::Text now holds Utf8Bytes and Message::Binary holds Bytes; add .into() at construction sites and .to_string() where test channels carry String.