### PR TITLE
fix: Eliminate early-stream audio glitches from clock sync warm-up

### DIFF
--- a/src/audio/synced_player.rs
+++ b/src/audio/synced_player.rs
@@ -332,6 +332,9 @@ struct CallbackStats {
     /// Schedule updates within the current correction episode; the sampling
     /// key for the correction trace line. Reset when correction disengages.
     correction_updates: u64,
+    /// Corrections the planner requested during clock warm-up that were
+    /// suppressed; the sampling key for the warm-up trace line.
+    warmup_suppressed_corrections: u64,
     /// Whether the queue was below [`QUEUE_LOW_WATER_US`] at the last render.
     /// Drives the edge-triggered low/recovered debug lines.
     queue_low: bool,
@@ -678,6 +681,9 @@ impl SyncedPlayer {
         let mut drop_counter = 0u32;
         let mut started = false;
         let mut handoff_warned = false;
+        let mut sync_settle_logged = false;
+        let mut last_callback_instant: Option<Instant> = None;
+        let mut last_playback_delta_us: Option<u64> = None;
         let mut last_generation = 0u64;
         let mut stats = CallbackStats::default();
         let initial_gain = cb_config.gain_control.gain();
@@ -784,6 +790,38 @@ impl SyncedPlayer {
                     let playback_delta = ts.playback.duration_since(ts.callback);
                     let playback_instant = callback_instant + playback_delta;
 
+                    // Both values are normally steady, so a step in either
+                    // explains a sync-error step: a callback gap means this
+                    // thread stalled; a playback-delta shift means the OS
+                    // moved the presentation timeline.
+                    let playback_delta_us = playback_delta.as_micros() as u64;
+                    if let Some(last) = last_callback_instant {
+                        let gap_us = callback_instant.duration_since(last).as_micros() as u64;
+                        let period_us = frames as u64 * 1_000_000 / u64::from(sample_rate.max(1));
+                        if gap_us > 2 * period_us {
+                            log::debug!(
+                                "Audio callback gap: {:.1}ms since previous (period ~{:.1}ms), callback={}, generation={}",
+                                us_to_ms(gap_us),
+                                us_to_ms(period_us),
+                                stats.callbacks,
+                                generation,
+                            );
+                        }
+                    }
+                    last_callback_instant = Some(callback_instant);
+                    if let Some(last) = last_playback_delta_us {
+                        if playback_delta_us.abs_diff(last) > 1_000 {
+                            log::debug!(
+                                "Output timeline shifted: playback_delta {:.1}ms -> {:.1}ms, callback={}, generation={}",
+                                us_to_ms(last),
+                                us_to_ms(playback_delta_us),
+                                stats.callbacks,
+                                generation,
+                            );
+                        }
+                    }
+                    last_playback_delta_us = Some(playback_delta_us);
+
                     // try_lock: skip sync if contended rather than blocking
                     // the audio thread. force_reanchor is sticky in the
                     // queue, so it will be retried on the next callback.
@@ -812,6 +850,16 @@ impl SyncedPlayer {
                         // planner chases a phantom error every callback.
                         let delay_us = cb_config.static_delay_us.load(Ordering::Relaxed);
                         let mut effective_cursor_us = cursor_us;
+                        let sync_settled = sync.is_settled();
+                        if sync_settled && !sync_settle_logged {
+                            sync_settle_logged = true;
+                            log::debug!(
+                                "Clock sync settled; corrections enabled: callback={}, suppressed_during_warmup={}, generation={}",
+                                stats.callbacks,
+                                stats.warmup_suppressed_corrections,
+                                generation,
+                            );
+                        }
 
                         if force_reanchor {
                             let mut reanchor_applied = false;
@@ -877,8 +925,13 @@ impl SyncedPlayer {
                         if let Some(expected_instant) = sync
                             .server_to_local_instant_with_latency(effective_cursor_us, delay_us)
                         {
+                            // Pre-start only: hold silence until the cursor's
+                            // scheduled instant. After start, "early" readings
+                            // are jitter — injecting silence here caused real
+                            // dropouts (audible blips); the planner handles
+                            // sustained earliness instead.
                             let early_window = Duration::from_millis(1);
-                            if playback_instant + early_window < expected_instant {
+                            if !started && playback_instant + early_window < expected_instant {
                                 stats.silent_callbacks += 1;
                                 if trace_logging && should_log_sample(stats.silent_callbacks) {
                                     let early_us = expected_instant
@@ -920,8 +973,34 @@ impl SyncedPlayer {
                                     .duration_since(playback_instant)
                                     .as_micros() as i64)
                             };
-                            let new_schedule =
+                            let planned_schedule =
                                 planner.plan(error_us, sample_rate, schedule.is_correcting());
+                            // While the sync estimate is still converging,
+                            // measured error is mostly movement of the
+                            // estimate itself; correcting for it chases
+                            // filter noise audibly. Trust the server's audio
+                            // until settled, honoring only gross reanchors.
+                            let new_schedule = if sync_settled || planned_schedule.reanchor {
+                                planned_schedule
+                            } else {
+                                if planned_schedule.is_correcting() {
+                                    stats.warmup_suppressed_corrections += 1;
+                                    if trace_logging
+                                        && should_log_sample(
+                                            stats.warmup_suppressed_corrections,
+                                        )
+                                    {
+                                        log::trace!(
+                                            "Sync correction suppressed during clock warm-up: callback={}, suppressed={}, error={:.3}ms, generation={}",
+                                            stats.callbacks,
+                                            stats.warmup_suppressed_corrections,
+                                            error_us as f64 / 1000.0,
+                                            generation,
+                                        );
+                                    }
+                                }
+                                CorrectionSchedule::default()
+                            };
                             if new_schedule != schedule {
                                 if new_schedule.is_correcting() != schedule.is_correcting() {
                                     if new_schedule.is_correcting() {
@@ -997,6 +1076,19 @@ impl SyncedPlayer {
                                 drop_counter = 0;
                                 stats.correction_updates = 0;
                             }
+                        } else if schedule.is_correcting() {
+                            // Conversions went dark (the implausible-drift
+                            // safety net): stop correcting rather than
+                            // resample blind on the stale cadence.
+                            log::debug!(
+                                "Sync conversions unavailable; clearing correction schedule: callback={}, generation={}",
+                                stats.callbacks,
+                                generation,
+                            );
+                            schedule = CorrectionSchedule::default();
+                            insert_counter = 0;
+                            drop_counter = 0;
+                            stats.correction_updates = 0;
                         }
                     }
 

--- a/src/protocol/client.rs
+++ b/src/protocol/client.rs
@@ -817,8 +817,9 @@ impl ProtocolClient {
             .await;
         });
 
-        // First two samples fire 10ms apart so the Kalman filter converges
-        // in ~20ms; the remainder run at 1Hz for ongoing drift correction.
+        // First two samples fire 10ms apart so an offset estimate (and
+        // playback start) is available almost immediately; drift converges
+        // over the following 1Hz samples (see TimeFilter).
         let sync_sender = WsSender {
             tx: out_tx.clone(),
             stream_state: Arc::clone(&stream_state),

--- a/src/sync/clock.rs
+++ b/src/sync/clock.rs
@@ -83,10 +83,19 @@ impl TimeFilter {
 
         if self.count == 1 {
             self.count = 2;
-            self.drift = (measurement as f64 - self.offset) / dt;
+            if dt < Self::MIN_DRIFT_BASELINE_MICROS {
+                // Δoffset/Δt over a tiny Δt is measurement noise amplified
+                // without bound. Seed drift at zero with uncertainty from the
+                // floored baseline; later Kalman updates refine it.
+                self.drift = 0.0;
+                self.drift_covariance = (self.offset_covariance + measurement_variance)
+                    / (Self::MIN_DRIFT_BASELINE_MICROS * Self::MIN_DRIFT_BASELINE_MICROS);
+            } else {
+                self.drift = (measurement as f64 - self.offset) / dt;
+                // Divide by dt^2, not dt: variance of (x/c) is var(x)/c^2.
+                self.drift_covariance = (self.offset_covariance + measurement_variance) / (dt * dt);
+            }
             self.offset = measurement as f64;
-            // Divide by dt^2, not dt: variance of (x/c) is var(x)/c^2.
-            self.drift_covariance = (self.offset_covariance + measurement_variance) / (dt * dt);
             self.offset_covariance = measurement_variance;
             self.current = TimeElement {
                 last_update: self.last_update,
@@ -150,6 +159,11 @@ impl TimeFilter {
         };
     }
 
+    /// Minimum baseline for estimating drift from the first two samples.
+    /// The fast-start pair can arrive bunched to near-zero spacing, so it
+    /// never qualifies; drift converges through later Kalman updates.
+    const MIN_DRIFT_BASELINE_MICROS: f64 = 100_000.0;
+
     /// Maximum plausible drift magnitude. Real clock drift between
     /// hardware oscillators is measured in ppm; 20% is far beyond
     /// physical reality. This is a last-resort safety net for a
@@ -181,8 +195,15 @@ impl TimeFilter {
         drift * drift >= threshold
     }
 
+    /// True when the filter would apply its drift estimate but it is beyond
+    /// physical plausibility. An implausible estimate the SNR gate already
+    /// rejects blocks nothing: conversions then run with zero drift.
+    fn conversions_blocked(&self) -> bool {
+        self.current.use_drift && !self.drift_is_plausible()
+    }
+
     fn effective_drift(&self) -> Option<f64> {
-        if !self.drift_is_plausible() {
+        if self.conversions_blocked() {
             return None;
         }
 
@@ -209,6 +230,16 @@ impl TimeFilter {
 
     fn is_synchronized(&self) -> bool {
         self.count >= 2 && self.offset_covariance.is_finite()
+    }
+
+    /// Samples required before the estimate is trusted for fine-grained
+    /// playback corrections. At the sync cadence (two fast-start samples,
+    /// then 1Hz — see `ProtocolClient`), ten samples settle ~9s after
+    /// connect.
+    const SETTLE_MIN_SAMPLES: u32 = 10;
+
+    fn is_settled(&self) -> bool {
+        self.count >= Self::SETTLE_MIN_SAMPLES
     }
 }
 
@@ -302,7 +333,7 @@ impl ClockSync {
         let max_error = (rtt / 2).max(1);
 
         let was_synced = self.filter.is_synchronized();
-        let was_plausible = self.filter.drift_is_plausible();
+        let was_blocked = self.filter.conversions_blocked();
         self.filter.update(measurement, max_error, t4);
         self.last_update = Some(Instant::now());
         log::trace!(
@@ -319,9 +350,9 @@ impl ClockSync {
                 rtt
             );
         }
-        if was_plausible && !self.filter.drift_is_plausible() {
+        if !was_blocked && self.filter.conversions_blocked() {
             log::warn!(
-                "Clock sync: drift {:.4} exceeded plausibility limit {}; \
+                "Clock sync: in-use drift {:.4} exceeded plausibility limit {}; \
                  time conversions will return None until it recovers",
                 self.filter.current.drift,
                 TimeFilter::MAX_DRIFT
@@ -401,6 +432,14 @@ impl ClockSync {
     /// Check if clock sync has converged
     pub fn is_synchronized(&self) -> bool {
         self.filter.is_synchronized()
+    }
+
+    /// Whether the estimate has settled enough to drive fine-grained
+    /// playback corrections. [`is_synchronized`](Self::is_synchronized)
+    /// means conversions are available at all: playback starts when
+    /// synchronized; the correction planner waits until settled.
+    pub fn is_settled(&self) -> bool {
+        self.filter.is_settled()
     }
 }
 
@@ -506,5 +545,69 @@ mod tests {
             with_bad.compute_client_time(10_000),
             without_bad.compute_client_time(10_000),
         );
+    }
+
+    #[test]
+    fn bunched_first_pair_seeds_zero_drift_and_keeps_conversions() {
+        let mut f = TimeFilter::new(0.01, 1.001);
+        // Fast-start pair arriving 190µs apart with a large offset delta:
+        // pre-fix, this computed drift = -6037/190 ≈ -31.8 and then blocked
+        // all conversions on implausibility for a full sample interval.
+        f.update(1_000_000, 12_797, 1_000);
+        f.update(994_000, 6_813, 1_190);
+
+        assert_eq!(f.drift, 0.0, "tiny-baseline pair must not estimate drift");
+        assert!(f.is_synchronized());
+        assert!(
+            f.compute_client_time(2_000_000).is_some(),
+            "conversions must be available right after the fast-start pair"
+        );
+    }
+
+    #[test]
+    fn long_baseline_pair_still_estimates_drift() {
+        let mut f = TimeFilter::new(0.01, 1.001);
+        f.update(1_000, 10, 1_000);
+        // dt = 200ms, at/above the baseline floor: quotient drift applies.
+        f.update(1_200, 10, 201_000);
+        assert!((f.drift - (200.0 / 200_000.0)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn unused_implausible_drift_does_not_block_conversions() {
+        let mut f = primed_filter();
+        // A diverged-looking drift that the SNR gate refuses to use must
+        // not veto conversions: effective drift is zero, which is safe.
+        f.current.drift = 5.0;
+        f.current.use_drift = false;
+        assert!(!f.conversions_blocked());
+        assert_eq!(f.effective_drift(), Some(0.0));
+    }
+
+    #[test]
+    fn in_use_implausible_drift_blocks_conversions() {
+        let mut f = primed_filter();
+        f.current.drift = 5.0;
+        f.current.use_drift = true;
+        assert!(f.conversions_blocked());
+        assert_eq!(f.effective_drift(), None);
+    }
+
+    #[test]
+    fn in_use_plausible_drift_is_applied() {
+        let mut f = primed_filter();
+        f.current.drift = 0.0001;
+        f.current.use_drift = true;
+        assert_eq!(f.effective_drift(), Some(0.0001));
+    }
+
+    #[test]
+    fn settles_after_minimum_samples() {
+        let mut f = TimeFilter::new(0.01, 1.001);
+        for i in 0..i64::from(TimeFilter::SETTLE_MIN_SAMPLES) {
+            assert!(!f.is_settled(), "must not settle before sample {}", i + 1);
+            f.update(1_000 + i, 10, 1_000 + i * 1_000_000);
+        }
+        assert!(f.is_settled());
     }
 }

--- a/tests/clock_sync.rs
+++ b/tests/clock_sync.rs
@@ -154,10 +154,11 @@ fn test_conversions_use_offset_only_when_drift_snr_is_low() {
 
     // First sample: offset = +100µs with tight uncertainty.
     sync.update(1_000, 1_100, 1_100, 1_000);
-    // Second sample: offset = +120µs, but a 1ms RTT gives the drift estimate
-    // high covariance. Its SNR is below 2σ, so both conversion directions
-    // should ignore drift and use only the current offset.
-    sync.update(1_000, 1_620, 1_620, 2_000);
+    // Second sample 200ms later (a legitimate drift baseline): offset =
+    // +120µs, but a 1ms RTT gives the drift estimate high covariance. Its
+    // SNR is below 2σ, so both conversion directions should ignore drift
+    // and use only the current offset.
+    sync.update(200_000, 200_620, 200_620, 201_000);
 
     assert!(sync.is_synchronized());
     assert_eq!(sync.server_to_client_micros(3_120), Some(3_000));
@@ -168,10 +169,11 @@ fn test_conversions_use_offset_only_when_drift_snr_is_low() {
 fn test_conversions_apply_drift_when_snr_is_high() {
     let mut sync = ClockSync::new(Arc::new(DefaultClock::new()));
 
-    // The same +100µs → +120µs drift as the low-SNR test, but with low-RTT
-    // samples. The covariance is small enough for the 2σ SNR gate to pass.
+    // Offset moves +100µs → +4100µs over a 200ms baseline (drift = 0.02),
+    // with low-RTT samples. The covariance is small enough for the 2σ SNR
+    // gate to pass, so conversions apply the drift estimate.
     sync.update(1_000, 1_100, 1_100, 1_000);
-    sync.update(2_000, 2_120, 2_120, 2_000);
+    sync.update(201_000, 205_100, 205_100, 201_000);
 
     assert!(sync.is_synchronized());
     assert_eq!(sync.server_to_client_micros(3_120), Some(2_980));
@@ -182,11 +184,12 @@ fn test_conversions_apply_drift_when_snr_is_high() {
 fn test_diverged_drift_returns_none() {
     let mut sync = ClockSync::new(Arc::new(DefaultClock::new()));
 
-    // Two samples 10µs apart where the NTP offset drops from 100 to 88,
-    // giving drift = -1.2 — far beyond any real hardware clock skew.
-    // Both conversions should return None rather than produce garbage.
-    sync.update(1000, 1100, 1100, 1000);
-    sync.update(1010, 1098, 1098, 1010);
+    // Two samples 200ms apart (a legitimate drift baseline) where the NTP
+    // offset collapses from +100µs to -99_900µs, giving drift = -0.5 with
+    // high SNR — far beyond any real hardware clock skew. The filter would
+    // apply that drift, so both conversions must refuse and return None.
+    sync.update(1_000, 1_100, 1_100, 1_000);
+    sync.update(201_000, 101_100, 101_100, 201_000);
 
     assert!(
         sync.server_to_client_micros(2000).is_none(),


### PR DESCRIPTION
I was able to reproduce some of the early-stream glitches that users have reported in the desktop app, and with sufficient logging to know where it's coming from. This attempts to fix it.

The fast-start sync pair arrives ~10ms apart, and estimating drift over that tiny baseline amplified measurement noise into garbage estimates that tripped the plausibility gate and blocked all time conversions for a full sample interval. Drift is now seeded at zero below a 100ms baseline (later Kalman updates refine it), and an implausible drift only blocks conversions when the SNR gate would actually apply it.

While the filter is still converging, measured sync error is mostly movement of the estimate itself, so the correction planner chased filter noise with audible insert/drop resampling. Fine-grained corrections now wait until the clock has settled (10 samples, ~9s at the sync cadence); gross reanchors still pass through. The early-silence gate is now pre-start only — injecting silence on jittery mid-stream readings caused audible dropouts — and a correcting schedule is cleared if conversions go dark.

Also adds callback-gap and playback-delta-shift debug diagnostics to explain future sync-error steps, and reworks the clock sync tests to use legitimate 200ms drift baselines.