### PR TITLE
Fix timing robustness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Stop drift corrections from chasing period-quantized presentation-timestamp
   noise: sync errors are floor-filtered (windowed minimum over ~1s, robust to
-  one-sided timestamp flapping at any duty cycle) and corrections only engage
-  after a sustained over-threshold streak, so measurement flapping no longer
-  triggers immediate drop/insert churn
+  one-sided timestamp flapping whenever the quiet mode is sampled at least
+  once per window), corrections only engage after a sustained over-threshold
+  streak, and stream reanchors derive their timeline anchor from the same
+  delta floor instead of a single wake's reading, so measurement flapping no
+  longer triggers immediate drop/insert churn or biased stream-start anchors
 - Promote the Windows audio callback thread to real-time priority (MMCSS via
   cpal's `realtime` feature), greatly reducing the chance of UI load starving
   the WASAPI event loop; a failed promotion is logged as a warning instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Stop drift corrections from chasing period-quantized presentation-timestamp
-  noise: sync errors are median-filtered over a ~1s window and corrections only
-  engage after a sustained over-threshold streak, so measurement flapping no
-  longer drops or repeats audible frames
+  noise: sync errors are floor-filtered (windowed minimum over ~1s, robust to
+  one-sided timestamp flapping at any duty cycle) and corrections only engage
+  after a sustained over-threshold streak, so measurement flapping no longer
+  triggers immediate drop/insert churn
 - Promote the Windows audio callback thread to real-time priority (MMCSS via
-  cpal's `realtime` feature) so UI load can no longer starve the WASAPI event
-  loop
+  cpal's `realtime` feature), greatly reducing the chance of UI load starving
+  the WASAPI event loop; a failed promotion is logged as a warning instead of
+  surfacing as a stream error
 - Request a 40ms WASAPI endpoint buffer by default on Windows (engine default
   is 20ms), giving late callback wakes margin before the mixer starves;
   explicit `SyncedPlayerConfig::buffer_size` still overrides

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Stop drift corrections from chasing period-quantized presentation-timestamp
+  noise: sync errors are median-filtered over a ~1s window and corrections only
+  engage after a sustained over-threshold streak, so measurement flapping no
+  longer drops or repeats audible frames
+- Promote the Windows audio callback thread to real-time priority (MMCSS via
+  cpal's `realtime` feature) so UI load can no longer starve the WASAPI event
+  loop
+- Request a 40ms WASAPI endpoint buffer by default on Windows (engine default
+  is 20ms), giving late callback wakes margin before the mixer starves;
+  explicit `SyncedPlayerConfig::buffer_size` still overrides
+
 ## [0.3.4](https://github.com/Sendspin/sendspin-rs/compare/v0.3.3...v0.3.4) - 2026-07-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Count correction engagements per playback generation and report the total in
+  the generation-change summary line, so "did the corrector ever fire?" is
+  answerable from logs retroactively even when debug logging was off
+
 ### Fixed
 
 - Stop drift corrections from chasing period-quantized presentation-timestamp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,9 @@ libc = "0.2"
 # callback thread runs at normal priority and loses its 10ms period race to
 # UI/WebView load, which shows up as callback gaps and endpoint-buffer
 # starvation. Windows-only: CoreAudio already schedules its callback threads
-# real-time, and Linux promotion needs the dbus/RtKit variant (realtime-dbus)
-# plus a system libdbus build dependency.
+# real-time (the feature is also inert there — cpal has no macOS
+# audio_thread_priority dependency), and Linux promotion needs the dbus/RtKit
+# variant (realtime-dbus) plus a system libdbus build dependency.
 cpal = { version = "0.18", features = ["realtime"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,10 +50,10 @@ libc = "0.2"
 [target.'cfg(target_os = "windows")'.dependencies]
 # `realtime` promotes cpal's WASAPI event-loop thread via MMCSS ("Pro Audio"),
 # falling back to SetThreadPriority(TIME_CRITICAL). Without it the audio
-# callback thread runs at normal priority and loses its 10ms period race to
-# UI/WebView load, which shows up as callback gaps and endpoint-buffer
-# starvation. Windows-only: CoreAudio already schedules its callback threads
-# real-time (the feature is also inert there — cpal has no macOS
+# callback thread runs at normal priority and can miss its engine-period
+# deadline under UI/WebView load, which shows up as callback gaps and
+# endpoint-buffer starvation. Windows-only: CoreAudio already schedules its
+# callback threads real-time (the feature is also inert there — cpal has no macOS
 # audio_thread_priority dependency), and Linux promotion needs the dbus/RtKit
 # variant (realtime-dbus) plus a system libdbus build dependency.
 cpal = { version = "0.18", features = ["realtime"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ libc = "0.2"
 [target.'cfg(target_os = "windows")'.dependencies]
 # `realtime` promotes cpal's WASAPI event-loop thread via MMCSS ("Pro Audio"),
 # falling back to SetThreadPriority(TIME_CRITICAL). Without it the audio
-# callback thread runs at normal priority and can miss its engine-period
-# deadline under UI/WebView load, which shows up as callback gaps and
-# endpoint-buffer starvation. Windows-only: CoreAudio already schedules its
-# callback threads real-time (the feature is also inert there — cpal has no macOS
-# audio_thread_priority dependency), and Linux promotion needs the dbus/RtKit
-# variant (realtime-dbus) plus a system libdbus build dependency.
+# callback thread runs at normal priority and can miss engine-period deadlines
+# under host load, which surfaces as callback gaps and endpoint-buffer
+# starvation. Windows-only: CoreAudio already schedules callback threads
+# real-time (and cpal has no macOS audio_thread_priority dependency, so the
+# feature would be inert), while Linux promotion needs the dbus/RtKit variant
+# (realtime-dbus) plus a system libdbus build dependency.
 cpal = { version = "0.18", features = ["realtime"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,16 @@ typed-builder = "0.23.2"
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+# `realtime` promotes cpal's WASAPI event-loop thread via MMCSS ("Pro Audio"),
+# falling back to SetThreadPriority(TIME_CRITICAL). Without it the audio
+# callback thread runs at normal priority and loses its 10ms period race to
+# UI/WebView load, which shows up as callback gaps and endpoint-buffer
+# starvation. Windows-only: CoreAudio already schedules its callback threads
+# real-time, and Linux promotion needs the dbus/RtKit variant (realtime-dbus)
+# plus a system libdbus build dependency.
+cpal = { version = "0.18", features = ["realtime"] }
+
 [dev-dependencies]
 tokio-test = "0.4"
 env_logger = "0.11"

--- a/examples/basic_client.rs
+++ b/examples/basic_client.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let args = Args::parse();
 
-    println!("Connecting to {}...", &args.server);
+    println!("Connecting to {}...", args.server);
 
     let test = ProtocolClientBuilder::builder()
         .client_id(uuid::Uuid::new_v4().to_string())

--- a/src/audio/sync_correction.rs
+++ b/src/audio/sync_correction.rs
@@ -119,25 +119,36 @@ impl Default for CorrectionPlanner {
 }
 
 /// Measurements kept by [`SyncErrorFilter`]. 101 callbacks is ~1s at the
-/// common 10ms WASAPI period (2-4s on 20-40ms periods): long enough to
-/// out-vote period-quantized flapping, short enough that a real displacement
-/// shifts the median within half a window.
-pub const SYNC_ERROR_WINDOW: usize = 101;
+/// common 10ms WASAPI period (2-4s on 20-40ms periods): long enough that the
+/// floor mode gets sampled even through dense flapping, short enough that a
+/// real displacement reaches the output within about a second.
+pub(crate) const SYNC_ERROR_WINDOW: usize = 101;
 
-/// Windowed median over recent sync-error measurements.
+/// Windowed minimum (floor tracker) over recent sync-error measurements.
 ///
 /// Audio presentation timestamps are quantized to the engine period: under
-/// scheduler jitter the wake-time padding snapshot flaps by a whole period
-/// (observed as a 2ms <-> 12ms alternation on shared-mode WASAPI) while the
-/// endpoint FIFO plays gaplessly. The instantaneous error is therefore
-/// bimodal measurement noise around the true alignment. The median tracks
-/// the majority mode and only moves when a shift *persists* — real
-/// displacement or clock drift — never on single-callback excursions, which
-/// makes it safe to feed to [`CorrectionPlanner`].
+/// scheduler jitter the wake-time padding snapshot jumps *up* by whole
+/// periods (observed as a 2ms <-> 12ms alternation on shared-mode WASAPI)
+/// while the endpoint FIFO plays gaplessly. The noise is one-sided — extra
+/// queued padding can only make a reading later, never earlier — so the
+/// window floor is the honest alignment estimate, and it stays put no matter
+/// how often the flap occurs or which mode holds the majority. A real
+/// displacement (engine starvation inserting silence, a cursor jump) shifts
+/// every reading *including the floor*, so it still reaches the planner
+/// within one window.
 ///
-/// Allocation-free and O(window) per update; sized for the audio callback.
+/// The response is deliberately asymmetric: a drop in error propagates
+/// immediately (a new low sample becomes the floor at once, so a running
+/// correction converges without overshoot), while a rise propagates only
+/// once the old floor ages out of the window — exactly the conservatism an
+/// engage decision wants. A spuriously *low* outlier would bias toward
+/// under-correction, the safe direction, and has no plausible physical
+/// source (padding cannot go below empty; clock-filter movement is
+/// microseconds).
+///
+/// Allocation-free, O(window) scan per update; sized for the audio callback.
 #[derive(Debug, Clone)]
-pub struct SyncErrorFilter {
+pub(crate) struct SyncErrorFilter {
     samples: [i64; SYNC_ERROR_WINDOW],
     len: usize,
     next: usize,
@@ -160,14 +171,14 @@ impl SyncErrorFilter {
         self.next = 0;
     }
 
-    /// True once the window is fully populated. Medians over a partial
-    /// window are still returned by [`SyncErrorFilter::update`], but engage
+    /// True once the window is fully populated. A floor over a partial
+    /// window is still returned by [`SyncErrorFilter::update`], but engage
     /// decisions should wait for warmth (see [`EngageGate`]).
     pub fn is_warm(&self) -> bool {
         self.len == SYNC_ERROR_WINDOW
     }
 
-    /// Record a raw error measurement (µs) and return the windowed median.
+    /// Record a raw error measurement (µs) and return the windowed minimum.
     pub fn update(&mut self, raw_error_us: i64) -> i64 {
         self.samples[self.next] = raw_error_us;
         self.next = (self.next + 1) % SYNC_ERROR_WINDOW;
@@ -176,11 +187,12 @@ impl SyncErrorFilter {
         }
         // While filling, the live samples are the contiguous prefix
         // (next == len until the first wrap); afterwards the whole array.
-        let mut scratch = [0i64; SYNC_ERROR_WINDOW];
-        let filled = &mut scratch[..self.len];
-        filled.copy_from_slice(&self.samples[..self.len]);
-        filled.sort_unstable();
-        filled[self.len / 2]
+        // Stale slots past `len` are never read. `len >= 1` here, so the
+        // fold always sees at least one real sample.
+        self.samples[..self.len]
+            .iter()
+            .copied()
+            .fold(i64::MAX, i64::min)
     }
 }
 
@@ -191,10 +203,11 @@ impl Default for SyncErrorFilter {
 }
 
 /// Consecutive correcting plans required before a correction may engage from
-/// idle: ~0.5s at a 10ms callback period. A phantom error (measurement flap)
-/// reverses within a callback or two and never builds a streak; drift and
-/// real displacement hold the streak trivially.
-pub const ENGAGE_STREAK_PLANS: u32 = 50;
+/// idle: ~0.5s at a 10ms callback period. Filtered errors already move at
+/// window timescale, so a genuine displacement holds the streak trivially;
+/// the gate keeps engagement evidence-backed across filter resets and
+/// warm-up, when the estimate is least trustworthy.
+pub(crate) const ENGAGE_STREAK_PLANS: u32 = 50;
 
 /// Gate between the planner and the applied schedule: an idle stream only
 /// starts correcting after a sustained run of correcting plans over a warm
@@ -202,15 +215,15 @@ pub const ENGAGE_STREAK_PLANS: u32 = 50;
 /// frames are audible as ticks), so engagement must be evidence-backed;
 /// disengagement and replanning of a running correction stay immediate
 /// because stopping or retuning is never audible.
-#[derive(Debug, Clone, Default)]
-pub struct EngageGate {
+#[derive(Debug, Clone)]
+pub(crate) struct EngageGate {
     streak: u32,
 }
 
 impl EngageGate {
     /// Create a gate with no accumulated streak.
     pub fn new() -> Self {
-        Self::default()
+        Self { streak: 0 }
     }
 
     /// Clear the accumulated streak.
@@ -241,6 +254,12 @@ impl EngageGate {
         } else {
             CorrectionSchedule::default()
         }
+    }
+}
+
+impl Default for EngageGate {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -410,45 +429,77 @@ mod tests {
     }
 
     #[test]
-    fn test_filter_median_ignores_minority_flap() {
-        // Period-quantized flapping: one +10ms excursion every third sample
-        // (the observed WASAPI padding alternation) must not move the median.
+    fn test_filter_floor_ignores_flap_at_any_duty() {
+        // Period-quantized flapping is one-sided (+one period). Even when
+        // the high mode holds a 90% majority — the case that defeats a
+        // median — the floor must stay on the quiet mode as long as it is
+        // sampled at least once per window.
         let mut filter = SyncErrorFilter::new();
-        let mut median = 0;
-        for i in 0..SYNC_ERROR_WINDOW * 2 {
-            let raw = if i % 3 == 0 { 10_000 } else { 0 };
-            median = filter.update(raw);
+        for i in 0..SYNC_ERROR_WINDOW * 3 {
+            let raw = if i % 10 == 0 { 0 } else { 10_000 };
+            let floor = filter.update(raw);
+            if i >= 1 {
+                assert_eq!(floor, 0, "flap majority must not lift the floor");
+            }
         }
-        assert_eq!(median, 0, "minority mode must not shift the median");
     }
 
     #[test]
-    fn test_filter_median_follows_persistent_step() {
-        // A real displacement shifts every subsequent measurement; the
-        // median must follow within ~half a window.
+    fn test_filter_floor_follows_persistent_rise_after_full_window() {
+        // A real displacement shifts every reading including the floor; the
+        // output must follow once the old floor ages out of the window.
         let mut filter = SyncErrorFilter::new();
         for _ in 0..SYNC_ERROR_WINDOW {
             filter.update(0);
         }
-        let mut median = 0;
-        for _ in 0..(SYNC_ERROR_WINDOW / 2 + 1) {
-            median = filter.update(10_000);
+        let mut floor = 0;
+        for i in 0..SYNC_ERROR_WINDOW {
+            floor = filter.update(10_000);
+            if i < SYNC_ERROR_WINDOW - 1 {
+                assert_eq!(floor, 0, "rise must wait for the window to age out");
+            }
         }
-        assert_eq!(median, 10_000, "persistent step must reach the median");
+        assert_eq!(floor, 10_000, "persistent rise must reach the output");
     }
 
     #[test]
-    fn test_filter_reset_clears_window() {
+    fn test_filter_floor_follows_drop_immediately() {
+        // A running correction shrinks the error; the floor must track the
+        // new low on the very next sample so the correction converges
+        // without overshoot.
         let mut filter = SyncErrorFilter::new();
         for _ in 0..SYNC_ERROR_WINDOW {
             filter.update(10_000);
         }
+        assert_eq!(filter.update(2_000), 2_000, "new low becomes the floor");
+    }
+
+    #[test]
+    fn test_filter_handles_negative_errors() {
+        // Negative true error (audio early, insert side) with one-sided
+        // positive excursions on top.
+        let mut filter = SyncErrorFilter::new();
+        for i in 0..SYNC_ERROR_WINDOW {
+            let raw = if i % 3 == 0 { 10_000 } else { -5_000 };
+            filter.update(raw);
+        }
+        assert_eq!(filter.update(-5_000), -5_000);
+    }
+
+    #[test]
+    fn test_filter_reset_clears_window() {
+        // Fill with a LOW value so stale slots would drag the floor down if
+        // reset failed to fence them off.
+        let mut filter = SyncErrorFilter::new();
+        for _ in 0..SYNC_ERROR_WINDOW {
+            filter.update(-10_000);
+        }
         filter.reset();
         assert!(!filter.is_warm());
         assert_eq!(
-            filter.update(0),
-            0,
-            "median after reset must reflect only new samples"
+            filter.update(5_000),
+            5_000,
+            "floor after reset must reflect only new samples"
         );
     }
 

--- a/src/audio/sync_correction.rs
+++ b/src/audio/sync_correction.rs
@@ -1,5 +1,5 @@
-// ABOUTME: Sync correction planner for drop/insert cadence
-// ABOUTME: Computes correction schedule from sync error and sample rate
+// ABOUTME: Sync correction planner for drop/insert cadence, plus the
+// ABOUTME: measurement filter and engage gate that keep it off phantom errors
 
 /// Correction schedule for drop/insert cadence.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -115,6 +115,132 @@ impl CorrectionPlanner {
 impl Default for CorrectionPlanner {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Measurements kept by [`SyncErrorFilter`]. 101 callbacks is ~1s at the
+/// common 10ms WASAPI period (2-4s on 20-40ms periods): long enough to
+/// out-vote period-quantized flapping, short enough that a real displacement
+/// shifts the median within half a window.
+pub const SYNC_ERROR_WINDOW: usize = 101;
+
+/// Windowed median over recent sync-error measurements.
+///
+/// Audio presentation timestamps are quantized to the engine period: under
+/// scheduler jitter the wake-time padding snapshot flaps by a whole period
+/// (observed as a 2ms <-> 12ms alternation on shared-mode WASAPI) while the
+/// endpoint FIFO plays gaplessly. The instantaneous error is therefore
+/// bimodal measurement noise around the true alignment. The median tracks
+/// the majority mode and only moves when a shift *persists* — real
+/// displacement or clock drift — never on single-callback excursions, which
+/// makes it safe to feed to [`CorrectionPlanner`].
+///
+/// Allocation-free and O(window) per update; sized for the audio callback.
+#[derive(Debug, Clone)]
+pub struct SyncErrorFilter {
+    samples: [i64; SYNC_ERROR_WINDOW],
+    len: usize,
+    next: usize,
+}
+
+impl SyncErrorFilter {
+    /// Create an empty (cold) filter.
+    pub fn new() -> Self {
+        Self {
+            samples: [0; SYNC_ERROR_WINDOW],
+            len: 0,
+            next: 0,
+        }
+    }
+
+    /// Discard all samples, e.g. after a reanchor or generation change made
+    /// prior measurements meaningless.
+    pub fn reset(&mut self) {
+        self.len = 0;
+        self.next = 0;
+    }
+
+    /// True once the window is fully populated. Medians over a partial
+    /// window are still returned by [`SyncErrorFilter::update`], but engage
+    /// decisions should wait for warmth (see [`EngageGate`]).
+    pub fn is_warm(&self) -> bool {
+        self.len == SYNC_ERROR_WINDOW
+    }
+
+    /// Record a raw error measurement (µs) and return the windowed median.
+    pub fn update(&mut self, raw_error_us: i64) -> i64 {
+        self.samples[self.next] = raw_error_us;
+        self.next = (self.next + 1) % SYNC_ERROR_WINDOW;
+        if self.len < SYNC_ERROR_WINDOW {
+            self.len += 1;
+        }
+        // While filling, the live samples are the contiguous prefix
+        // (next == len until the first wrap); afterwards the whole array.
+        let mut scratch = [0i64; SYNC_ERROR_WINDOW];
+        let filled = &mut scratch[..self.len];
+        filled.copy_from_slice(&self.samples[..self.len]);
+        filled.sort_unstable();
+        filled[self.len / 2]
+    }
+}
+
+impl Default for SyncErrorFilter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Consecutive correcting plans required before a correction may engage from
+/// idle: ~0.5s at a 10ms callback period. A phantom error (measurement flap)
+/// reverses within a callback or two and never builds a streak; drift and
+/// real displacement hold the streak trivially.
+pub const ENGAGE_STREAK_PLANS: u32 = 50;
+
+/// Gate between the planner and the applied schedule: an idle stream only
+/// starts correcting after a sustained run of correcting plans over a warm
+/// filter. Every engaged correction mutates real audio (dropped or repeated
+/// frames are audible as ticks), so engagement must be evidence-backed;
+/// disengagement and replanning of a running correction stay immediate
+/// because stopping or retuning is never audible.
+#[derive(Debug, Clone, Default)]
+pub struct EngageGate {
+    streak: u32,
+}
+
+impl EngageGate {
+    /// Create a gate with no accumulated streak.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Clear the accumulated streak.
+    pub fn reset(&mut self) {
+        self.streak = 0;
+    }
+
+    /// Admit or suppress a planned schedule.
+    ///
+    /// `currently_correcting` is whether a correction episode is already
+    /// running; `filter_warm` is whether the error filter window is fully
+    /// populated. Reanchor plans always pass: they indicate gross real
+    /// displacement where a delayed reaction is worse than a rare false
+    /// positive.
+    pub fn admit(
+        &mut self,
+        planned: CorrectionSchedule,
+        currently_correcting: bool,
+        filter_warm: bool,
+    ) -> CorrectionSchedule {
+        if planned.reanchor || currently_correcting || !planned.is_correcting() {
+            self.streak = 0;
+            return planned;
+        }
+        self.streak = self.streak.saturating_add(1);
+        if filter_warm && self.streak >= ENGAGE_STREAK_PLANS {
+            planned
+        } else {
+            CorrectionSchedule::default()
+        }
     }
 }
 
@@ -260,6 +386,138 @@ mod tests {
         assert_eq!(
             s.drop_every_n_frames, 25,
             "large drift should be capped at max speed correction (interval = 25 frames)"
+        );
+    }
+
+    #[test]
+    fn test_filter_constant_input_passes_through() {
+        let mut filter = SyncErrorFilter::new();
+        for _ in 0..SYNC_ERROR_WINDOW {
+            assert_eq!(filter.update(4_000), 4_000);
+        }
+        assert!(filter.is_warm());
+    }
+
+    #[test]
+    fn test_filter_warms_only_after_full_window() {
+        let mut filter = SyncErrorFilter::new();
+        for _ in 0..SYNC_ERROR_WINDOW - 1 {
+            filter.update(0);
+            assert!(!filter.is_warm());
+        }
+        filter.update(0);
+        assert!(filter.is_warm());
+    }
+
+    #[test]
+    fn test_filter_median_ignores_minority_flap() {
+        // Period-quantized flapping: one +10ms excursion every third sample
+        // (the observed WASAPI padding alternation) must not move the median.
+        let mut filter = SyncErrorFilter::new();
+        let mut median = 0;
+        for i in 0..SYNC_ERROR_WINDOW * 2 {
+            let raw = if i % 3 == 0 { 10_000 } else { 0 };
+            median = filter.update(raw);
+        }
+        assert_eq!(median, 0, "minority mode must not shift the median");
+    }
+
+    #[test]
+    fn test_filter_median_follows_persistent_step() {
+        // A real displacement shifts every subsequent measurement; the
+        // median must follow within ~half a window.
+        let mut filter = SyncErrorFilter::new();
+        for _ in 0..SYNC_ERROR_WINDOW {
+            filter.update(0);
+        }
+        let mut median = 0;
+        for _ in 0..(SYNC_ERROR_WINDOW / 2 + 1) {
+            median = filter.update(10_000);
+        }
+        assert_eq!(median, 10_000, "persistent step must reach the median");
+    }
+
+    #[test]
+    fn test_filter_reset_clears_window() {
+        let mut filter = SyncErrorFilter::new();
+        for _ in 0..SYNC_ERROR_WINDOW {
+            filter.update(10_000);
+        }
+        filter.reset();
+        assert!(!filter.is_warm());
+        assert_eq!(
+            filter.update(0),
+            0,
+            "median after reset must reflect only new samples"
+        );
+    }
+
+    fn correcting_plan() -> CorrectionSchedule {
+        CorrectionSchedule {
+            insert_every_n_frames: 0,
+            drop_every_n_frames: 200,
+            reanchor: false,
+        }
+    }
+
+    #[test]
+    fn test_gate_requires_sustained_streak() {
+        let mut gate = EngageGate::new();
+        for _ in 0..ENGAGE_STREAK_PLANS - 1 {
+            let admitted = gate.admit(correcting_plan(), false, true);
+            assert!(!admitted.is_correcting(), "streak not yet sustained");
+        }
+        let admitted = gate.admit(correcting_plan(), false, true);
+        assert!(admitted.is_correcting(), "sustained streak must engage");
+    }
+
+    #[test]
+    fn test_gate_streak_resets_on_idle_plan() {
+        let mut gate = EngageGate::new();
+        for _ in 0..ENGAGE_STREAK_PLANS - 1 {
+            gate.admit(correcting_plan(), false, true);
+        }
+        gate.admit(CorrectionSchedule::default(), false, true);
+        let admitted = gate.admit(correcting_plan(), false, true);
+        assert!(
+            !admitted.is_correcting(),
+            "an idle plan must reset the streak"
+        );
+    }
+
+    #[test]
+    fn test_gate_cold_filter_never_engages() {
+        let mut gate = EngageGate::new();
+        for _ in 0..ENGAGE_STREAK_PLANS * 2 {
+            let admitted = gate.admit(correcting_plan(), false, false);
+            assert!(!admitted.is_correcting(), "cold filter must not engage");
+        }
+    }
+
+    #[test]
+    fn test_gate_reanchor_bypasses() {
+        let mut gate = EngageGate::new();
+        let reanchor = CorrectionSchedule {
+            insert_every_n_frames: 0,
+            drop_every_n_frames: 0,
+            reanchor: true,
+        };
+        let admitted = gate.admit(reanchor, false, false);
+        assert!(admitted.reanchor, "reanchor must bypass the gate");
+    }
+
+    #[test]
+    fn test_gate_running_correction_replans_freely() {
+        let mut gate = EngageGate::new();
+        let admitted = gate.admit(correcting_plan(), true, true);
+        assert!(
+            admitted.is_correcting(),
+            "a running correction must replan without gating"
+        );
+        let disengage = gate.admit(CorrectionSchedule::default(), true, true);
+        assert!(
+            !disengage.is_correcting(),
+            "disengage must pass immediately"
         );
     }
 }

--- a/src/audio/sync_correction.rs
+++ b/src/audio/sync_correction.rs
@@ -432,10 +432,10 @@ mod tests {
 
     #[test]
     fn test_filter_floor_ignores_flap_at_any_duty() {
-        // Period-quantized flapping is one-sided (+one period). Even when
-        // the high mode holds a 90% majority — the case that defeats a
-        // median — the floor must stay on the quiet mode as long as it is
-        // sampled at least once per window.
+        // Period-quantized flapping is one-sided (+one period). Even a 90%
+        // majority in the high mode — enough to drag any central-tendency
+        // estimate — must not lift the floor while the quiet mode is sampled
+        // at least once per window.
         let mut filter = SyncErrorFilter::new();
         for i in 0..SYNC_ERROR_WINDOW * 3 {
             let raw = if i % 10 == 0 { 0 } else { 10_000 };

--- a/src/audio/sync_correction.rs
+++ b/src/audio/sync_correction.rs
@@ -131,20 +131,22 @@ pub(crate) const SYNC_ERROR_WINDOW: usize = 101;
 /// periods (observed as a 2ms <-> 12ms alternation on shared-mode WASAPI)
 /// while the endpoint FIFO plays gaplessly. The noise is one-sided — extra
 /// queued padding can only make a reading later, never earlier — so the
-/// window floor is the honest alignment estimate, and it stays put no matter
-/// how often the flap occurs or which mode holds the majority. A real
-/// displacement (engine starvation inserting silence, a cursor jump) shifts
-/// every reading *including the floor*, so it still reaches the planner
-/// within one window.
+/// window floor is the honest alignment estimate: it holds regardless of
+/// which mode has the majority, so long as the floor mode is sampled at
+/// least once per window. A real displacement (engine starvation inserting
+/// silence, a cursor jump) shifts every reading *including the floor*, so it
+/// still reaches the planner within one window.
 ///
 /// The response is deliberately asymmetric: a drop in error propagates
 /// immediately (a new low sample becomes the floor at once, so a running
 /// correction converges without overshoot), while a rise propagates only
 /// once the old floor ages out of the window — exactly the conservatism an
 /// engage decision wants. A spuriously *low* outlier would bias toward
-/// under-correction, the safe direction, and has no plausible physical
-/// source (padding cannot go below empty; clock-filter movement is
-/// microseconds).
+/// under-correction, the safe direction. The padding term never produces
+/// one (padding cannot go below empty); the clock filter normally moves by
+/// microseconds once settled, though an outlier time sample can still step
+/// the estimate by low single-digit milliseconds in either direction — a
+/// negative step costs at most one window of under-correction.
 ///
 /// Allocation-free, O(window) scan per update; sized for the audio callback.
 #[derive(Debug, Clone)]
@@ -484,6 +486,39 @@ mod tests {
             filter.update(raw);
         }
         assert_eq!(filter.update(-5_000), -5_000);
+    }
+
+    #[test]
+    fn test_filter_single_low_evicted_exactly_after_window() {
+        // One low among highs must stop being the floor exactly WINDOW
+        // updates after it was recorded.
+        let mut filter = SyncErrorFilter::new();
+        filter.update(1_000);
+        for i in 0..SYNC_ERROR_WINDOW - 1 {
+            assert_eq!(filter.update(10_000), 1_000, "low still in window at {i}");
+        }
+        assert_eq!(
+            filter.update(10_000),
+            10_000,
+            "low must age out exactly one window after it was recorded"
+        );
+    }
+
+    #[test]
+    fn test_filter_tracks_min_across_multiple_wraps() {
+        // Distinct values across several ring cycles: the floor must always
+        // equal the true minimum of the last WINDOW samples.
+        let mut filter = SyncErrorFilter::new();
+        let mut recent: Vec<i64> = Vec::new();
+        for i in 0..(SYNC_ERROR_WINDOW as i64 * 5) {
+            let value = (i * 37) % 1_000 + if i % 13 == 0 { -500 } else { 0 };
+            recent.push(value);
+            if recent.len() > SYNC_ERROR_WINDOW {
+                recent.remove(0);
+            }
+            let expected = *recent.iter().min().unwrap();
+            assert_eq!(filter.update(value), expected, "mismatch at update {i}");
+        }
     }
 
     #[test]

--- a/src/audio/synced_player.rs
+++ b/src/audio/synced_player.rs
@@ -97,8 +97,9 @@ const fn static_delay_ms_to_us(delay_ms: u16) -> u64 {
 /// buffer completely and the next slip starves the mixer (silence insertion —
 /// a real timeline displacement). Requesting ~40ms deepens the endpoint
 /// queue only — the engine still wakes us every period — leaving roughly
-/// three periods queued at each wake, so the mixer survives two to three
-/// consecutive late wakes. That margin matters even with MMCSS: the thread
+/// three periods queued at each wake, so the mixer reliably survives two
+/// consecutive late wakes (a third lands exactly at empty). That margin
+/// matters even with MMCSS: the thread
 /// shares the real-time class with every other pro-audio client and will
 /// sometimes lose its slot.
 ///
@@ -738,6 +739,16 @@ impl SyncedPlayer {
         let mut sync_settle_logged = false;
         let mut last_callback_instant: Option<Instant> = None;
         let mut last_playback_delta_us: Option<u64> = None;
+        // Running minimum of the presentation-latency snapshot, per
+        // generation. Reanchors derive their timeline anchor from this floor
+        // rather than one wake's reading: padding noise is one-sided (see
+        // SyncErrorFilter) and flap storms cluster at exactly stream start,
+        // so a single-sample anchor is biased toward the high mode and bakes
+        // a one-period offset into the timeline that corrections must then
+        // audibly unwind. A stale floor after a mid-stream latency-regime
+        // shift costs at most a one-time period realignment — the same cost
+        // any regime shift already carries.
+        let mut min_playback_delta_us = u64::MAX;
         let mut last_generation = 0u64;
         let mut stats = CallbackStats::default();
         let initial_gain = cb_config.gain_control.gain();
@@ -834,6 +845,7 @@ impl SyncedPlayer {
                         drop_counter = 0;
                         error_filter.reset();
                         engage_gate.reset();
+                        min_playback_delta_us = u64::MAX;
                         stats.reset_for_generation();
                         for sample in last_frame.iter_mut() {
                             *sample = i32::EQUILIBRIUM;
@@ -877,6 +889,7 @@ impl SyncedPlayer {
                         }
                     }
                     last_playback_delta_us = Some(playback_delta_us);
+                    min_playback_delta_us = min_playback_delta_us.min(playback_delta_us);
 
                     // try_lock: skip sync if contended rather than blocking
                     // the audio thread. force_reanchor is sticky in the
@@ -923,8 +936,14 @@ impl SyncedPlayer {
 
                         if force_reanchor {
                             let mut reanchor_applied = false;
+                            // Anchor from the delta floor, not this wake's
+                            // reading (see min_playback_delta_us above). The
+                            // floor already includes this callback's sample,
+                            // so it is never u64::MAX here.
+                            let anchor_instant = callback_instant
+                                + Duration::from_micros(min_playback_delta_us);
                             let handoff_instant = if started {
-                                playback_instant
+                                anchor_instant
                             } else {
                                 // Startup handoff: anchor to `+ handoff_delta` (this buffer's
                                 // end = the next callback's start) so the next start gate sees
@@ -932,7 +951,7 @@ impl SyncedPlayer {
                                 // cursor by one buffer, so we stay silent for this one period.
                                 let handoff_delta =
                                     Duration::from_secs_f64(frames as f64 / sample_rate as f64);
-                                playback_instant + handoff_delta
+                                anchor_instant + handoff_delta
                             };
                             let client_micros =
                                 sync.instant_to_client_micros(handoff_instant) + delay_us as i64;
@@ -1115,6 +1134,10 @@ impl SyncedPlayer {
                                             generation,
                                         );
                                     } else {
+                                        // The floor lags upward moves, so at
+                                        // disengage `error=` can read larger
+                                        // in magnitude than the live
+                                        // `raw_error=` — expected, not a bug.
                                         log::debug!(
                                             "Sync correction disengaged: error={:.3}ms, raw_error={:.3}ms, callback={}, generation={}",
                                             error_us as f64 / 1000.0,
@@ -1161,8 +1184,12 @@ impl SyncedPlayer {
                             if schedule.reanchor {
                                 // Mirror of the start-gate subtraction: audio
                                 // emitted now is heard `delay_us` later, so
-                                // anchor the cursor to that hear-instant.
-                                let client_micros = sync.instant_to_client_micros(playback_instant)
+                                // anchor the cursor to that hear-instant —
+                                // derived from the delta floor, not this
+                                // wake's reading (see min_playback_delta_us).
+                                let anchor_instant = callback_instant
+                                    + Duration::from_micros(min_playback_delta_us);
+                                let client_micros = sync.instant_to_client_micros(anchor_instant)
                                     + delay_us as i64;
                                 if let Some(server_time) =
                                     sync.client_to_server_micros(client_micros)
@@ -1391,21 +1418,20 @@ impl SyncedPlayer {
                     }
                     },
                     move |err| {
-                        let message = err.to_string();
-                        // cpal's `realtime` feature reports a failed thread
-                        // promotion through this callback; playback continues
-                        // at normal priority. Warn without storing:
+                        // cpal reports a refused real-time promotion as
+                        // RealtimeDenied ("Audio will still play"); playback
+                        // continues at normal priority. Warn without storing:
                         // take_error()/has_error() signal fatal stream
                         // failures, and a consumer must not tear down a
                         // working stream over a scheduling downgrade.
-                        if message.contains("promote audio thread") {
+                        if err.kind() == cpal::ErrorKind::RealtimeDenied {
                             log::warn!(
-                                "Audio thread priority promotion failed (non-fatal): {message}"
+                                "Audio thread priority promotion failed (non-fatal): {err}"
                             );
                             return;
                         }
-                        log::error!("Audio stream error: {message}");
-                        *error.lock() = Some(message);
+                        log::error!("Audio stream error: {err}");
+                        *error.lock() = Some(err.to_string());
                     },
                     None,
                 )

--- a/src/audio/synced_player.rs
+++ b/src/audio/synced_player.rs
@@ -2,7 +2,9 @@
 // ABOUTME: Uses DAC callback timestamps to drop/insert frames for alignment
 
 use crate::audio::gain::{GainControl, GainRamp};
-use crate::audio::sync_correction::{CorrectionPlanner, CorrectionSchedule};
+use crate::audio::sync_correction::{
+    CorrectionPlanner, CorrectionSchedule, EngageGate, SyncErrorFilter,
+};
 use crate::audio::{AudioBuffer, AudioFormat};
 use crate::error::Error;
 use crate::log_sampling::should_log_sample;
@@ -344,6 +346,9 @@ struct CallbackStats {
     /// Corrections the planner requested during clock warm-up that were
     /// suppressed; the sampling key for the warm-up trace line.
     warmup_suppressed_corrections: u64,
+    /// Corrections the planner requested that the engage gate suppressed
+    /// while awaiting a sustained error; the sampling key for its trace line.
+    gate_suppressed_corrections: u64,
     /// Whether the queue was below [`QUEUE_LOW_WATER_US`] at the last render.
     /// Drives the edge-triggered low/recovered debug lines.
     queue_low: bool,
@@ -684,6 +689,8 @@ impl SyncedPlayer {
         let channels = format.channels as usize;
         let sample_rate = format.sample_rate;
         let planner = CorrectionPlanner::new();
+        let mut error_filter = SyncErrorFilter::new();
+        let mut engage_gate = EngageGate::new();
         let mut last_frame = vec![i32::EQUILIBRIUM; channels];
         let mut schedule = CorrectionSchedule::default();
         let mut insert_counter = 0u32;
@@ -787,6 +794,8 @@ impl SyncedPlayer {
                         schedule = CorrectionSchedule::default();
                         insert_counter = 0;
                         drop_counter = 0;
+                        error_filter.reset();
+                        engage_gate.reset();
                         stats.reset_for_generation();
                         for sample in last_frame.iter_mut() {
                             *sample = i32::EQUILIBRIUM;
@@ -862,6 +871,10 @@ impl SyncedPlayer {
                         let sync_settled = sync.is_settled();
                         if sync_settled && !sync_settle_logged {
                             sync_settle_logged = true;
+                            // Warm-up measurements track the converging clock
+                            // estimate, not playback; start the filter fresh.
+                            error_filter.reset();
+                            engage_gate.reset();
                             log::debug!(
                                 "Clock sync settled; corrections enabled: callback={}, suppressed_during_warmup={}, generation={}",
                                 stats.callbacks,
@@ -973,7 +986,7 @@ impl SyncedPlayer {
                                 );
                             }
 
-                            let error_us = if playback_instant >= expected_instant {
+                            let raw_error_us = if playback_instant >= expected_instant {
                                 playback_instant
                                     .duration_since(expected_instant)
                                     .as_micros() as i64
@@ -982,8 +995,39 @@ impl SyncedPlayer {
                                     .duration_since(playback_instant)
                                     .as_micros() as i64)
                             };
+                            // Median-filter the measurement: presentation
+                            // timestamps quantize to the engine period, so a
+                            // single callback's reading can be a whole period
+                            // off while the endpoint FIFO plays gaplessly
+                            // (see SyncErrorFilter). Plan against the stable
+                            // majority, never one wake's snapshot.
+                            let error_us = error_filter.update(raw_error_us);
                             let planned_schedule =
                                 planner.plan(error_us, sample_rate, schedule.is_correcting());
+                            // Starting a correction mutates real audio, so it
+                            // must be backed by a sustained error over a warm
+                            // filter; phantom flaps never build the streak.
+                            let gated_schedule = engage_gate.admit(
+                                planned_schedule,
+                                schedule.is_correcting(),
+                                error_filter.is_warm(),
+                            );
+                            if gated_schedule != planned_schedule {
+                                stats.gate_suppressed_corrections += 1;
+                                if trace_logging
+                                    && should_log_sample(stats.gate_suppressed_corrections)
+                                {
+                                    log::trace!(
+                                        "Sync correction awaiting sustained error: callback={}, suppressed={}, error={:.3}ms, raw_error={:.3}ms, generation={}",
+                                        stats.callbacks,
+                                        stats.gate_suppressed_corrections,
+                                        error_us as f64 / 1000.0,
+                                        raw_error_us as f64 / 1000.0,
+                                        generation,
+                                    );
+                                }
+                            }
+                            let planned_schedule = gated_schedule;
                             // While the sync estimate is still converging,
                             // measured error is mostly movement of the
                             // estimate itself; correcting for it chases
@@ -1000,10 +1044,11 @@ impl SyncedPlayer {
                                         )
                                     {
                                         log::trace!(
-                                            "Sync correction suppressed during clock warm-up: callback={}, suppressed={}, error={:.3}ms, generation={}",
+                                            "Sync correction suppressed during clock warm-up: callback={}, suppressed={}, error={:.3}ms, raw_error={:.3}ms, generation={}",
                                             stats.callbacks,
                                             stats.warmup_suppressed_corrections,
                                             error_us as f64 / 1000.0,
+                                            raw_error_us as f64 / 1000.0,
                                             generation,
                                         );
                                     }
@@ -1014,8 +1059,9 @@ impl SyncedPlayer {
                                 if new_schedule.is_correcting() != schedule.is_correcting() {
                                     if new_schedule.is_correcting() {
                                         log::debug!(
-                                            "Sync correction engaged: error={:.3}ms, insert_every={}, drop_every={}, reanchor={}, callback={}, generation={}",
+                                            "Sync correction engaged: error={:.3}ms, raw_error={:.3}ms, insert_every={}, drop_every={}, reanchor={}, callback={}, generation={}",
                                             error_us as f64 / 1000.0,
+                                            raw_error_us as f64 / 1000.0,
                                             new_schedule.insert_every_n_frames,
                                             new_schedule.drop_every_n_frames,
                                             new_schedule.reanchor,
@@ -1024,8 +1070,9 @@ impl SyncedPlayer {
                                         );
                                     } else {
                                         log::debug!(
-                                            "Sync correction disengaged: error={:.3}ms, callback={}, generation={}",
+                                            "Sync correction disengaged: error={:.3}ms, raw_error={:.3}ms, callback={}, generation={}",
                                             error_us as f64 / 1000.0,
+                                            raw_error_us as f64 / 1000.0,
                                             stats.callbacks,
                                             generation,
                                         );
@@ -1045,10 +1092,11 @@ impl SyncedPlayer {
                                         && should_log_sample(stats.correction_updates)
                                     {
                                         log::trace!(
-                                            "Sync correction updated: callback={}, correction_update={}, error={:.3}ms, insert_every={}, drop_every={}, reanchor={}, queued={:.1}ms, generation={}",
+                                            "Sync correction updated: callback={}, correction_update={}, error={:.3}ms, raw_error={:.3}ms, insert_every={}, drop_every={}, reanchor={}, queued={:.1}ms, generation={}",
                                             stats.callbacks,
                                             stats.correction_updates,
                                             error_us as f64 / 1000.0,
+                                            raw_error_us as f64 / 1000.0,
                                             new_schedule.insert_every_n_frames,
                                             new_schedule.drop_every_n_frames,
                                             new_schedule.reanchor,
@@ -1084,6 +1132,10 @@ impl SyncedPlayer {
                                 insert_counter = 0;
                                 drop_counter = 0;
                                 stats.correction_updates = 0;
+                                // The cursor just jumped; prior measurements
+                                // describe the old timeline.
+                                error_filter.reset();
+                                engage_gate.reset();
                             }
                         } else if schedule.is_correcting() {
                             // Conversions went dark (the implausible-drift
@@ -1098,6 +1150,8 @@ impl SyncedPlayer {
                             insert_counter = 0;
                             drop_counter = 0;
                             stats.correction_updates = 0;
+                            error_filter.reset();
+                            engage_gate.reset();
                         }
                     }
 

--- a/src/audio/synced_player.rs
+++ b/src/audio/synced_player.rs
@@ -386,6 +386,11 @@ struct CallbackStats {
     /// Corrections the planner requested that the engage gate suppressed
     /// while awaiting a sustained error; the sampling key for its trace line.
     gate_suppressed_corrections: u64,
+    /// Correction episodes started (idle -> correcting transitions, including
+    /// reanchor engagements). Mirrors the "Sync correction engaged" debug
+    /// line 1:1 so the generation summary can answer "did the corrector ever
+    /// fire?" retroactively even when debug logging was off during playback.
+    correction_engagements: u64,
     /// Whether the queue was below [`QUEUE_LOW_WATER_US`] at the last render.
     /// Drives the edge-triggered low/recovered debug lines.
     queue_low: bool,
@@ -827,7 +832,7 @@ impl SyncedPlayer {
                     };
                     if generation != last_generation {
                         log::debug!(
-                            "Playback queue generation changed: {} -> {}, queued={:.1}ms, buffers={}, callbacks={}, silent_callbacks={}, underrun_callbacks={}, underrun_frames={}, sync_lock_misses={}",
+                            "Playback queue generation changed: {} -> {}, queued={:.1}ms, buffers={}, callbacks={}, silent_callbacks={}, underrun_callbacks={}, underrun_frames={}, sync_lock_misses={}, correction_engagements={}",
                             last_generation,
                             generation,
                             us_to_ms(queued_us),
@@ -837,6 +842,7 @@ impl SyncedPlayer {
                             stats.underrun_callbacks,
                             stats.underrun_frames,
                             stats.sync_lock_misses,
+                            stats.correction_engagements,
                         );
                         last_generation = generation;
                         started = false;
@@ -1123,6 +1129,7 @@ impl SyncedPlayer {
                             if new_schedule != schedule {
                                 if new_schedule.is_correcting() != schedule.is_correcting() {
                                     if new_schedule.is_correcting() {
+                                        stats.correction_engagements += 1;
                                         log::debug!(
                                             "Sync correction engaged: error={:.3}ms, raw_error={:.3}ms, insert_every={}, drop_every={}, reanchor={}, callback={}, generation={}",
                                             error_us as f64 / 1000.0,

--- a/src/audio/synced_player.rs
+++ b/src/audio/synced_player.rs
@@ -92,12 +92,15 @@ const fn static_delay_ms_to_us(delay_ms: u16) -> u64 {
 /// Endpoint buffer requested on Windows when the caller does not override
 /// [`SyncedPlayerConfig::buffer_size`].
 ///
-/// WASAPI's shared-mode default allocates two 10ms engine periods, so one
-/// late wake of the event-loop thread drains the buffer completely and the
-/// next slip starves the mixer (silence insertion — a real timeline
-/// displacement). Four periods of margin make an occasional late wake a
-/// non-event; even promoted to MMCSS the thread shares the real-time class
-/// with every other pro-audio client and will sometimes lose its slot.
+/// WASAPI's shared-mode default allocates two engine periods (20ms at the
+/// common 10ms period), so one late wake of the event-loop thread drains the
+/// buffer completely and the next slip starves the mixer (silence insertion —
+/// a real timeline displacement). Requesting ~40ms deepens the endpoint
+/// queue only — the engine still wakes us every period — leaving roughly
+/// three periods queued at each wake, so the mixer survives two to three
+/// consecutive late wakes. That margin matters even with MMCSS: the thread
+/// shares the real-time class with every other pro-audio client and will
+/// sometimes lose its slot.
 ///
 /// Depth does not affect inter-device sync: the sync error is measured
 /// against padding-compensated presentation timestamps, so queued depth
@@ -851,7 +854,7 @@ impl SyncedPlayer {
                     if let Some(last) = last_callback_instant {
                         let gap_us = callback_instant.duration_since(last).as_micros() as u64;
                         let period_us = frames as u64 * 1_000_000 / u64::from(sample_rate.max(1));
-                        if gap_us > 2 * period_us {
+                        if gap_us >= 2 * period_us {
                             log::debug!(
                                 "Audio callback gap: {:.1}ms since previous (period ~{:.1}ms), callback={}, generation={}",
                                 us_to_ms(gap_us),
@@ -947,6 +950,13 @@ impl SyncedPlayer {
                                         schedule = CorrectionSchedule::default();
                                         insert_counter = 0;
                                         drop_counter = 0;
+                                        // The cursor just jumped (e.g. a
+                                        // static-delay change, which does not
+                                        // bump the generation); prior
+                                        // measurements describe the old
+                                        // timeline.
+                                        error_filter.reset();
+                                        engage_gate.reset();
                                         log::debug!(
                                             "Sync reanchor applied: cursor reset to server_time={cursor_us}µs"
                                         );
@@ -1030,12 +1040,13 @@ impl SyncedPlayer {
                                     .duration_since(playback_instant)
                                     .as_micros() as i64)
                             };
-                            // Median-filter the measurement: presentation
-                            // timestamps quantize to the engine period, so a
-                            // single callback's reading can be a whole period
-                            // off while the endpoint FIFO plays gaplessly
-                            // (see SyncErrorFilter). Plan against the stable
-                            // majority, never one wake's snapshot.
+                            // Floor-filter the measurement (windowed min):
+                            // presentation timestamps quantize to the engine
+                            // period, so a single callback's reading can sit
+                            // a whole period above the true alignment while
+                            // the endpoint FIFO plays gaplessly (see
+                            // SyncErrorFilter). Plan against the window
+                            // floor, never one wake's snapshot.
                             let error_us = error_filter.update(raw_error_us);
                             let planned_schedule =
                                 planner.plan(error_us, sample_rate, schedule.is_correcting());
@@ -1380,8 +1391,21 @@ impl SyncedPlayer {
                     }
                     },
                     move |err| {
-                        log::error!("Audio stream error: {}", err);
-                        *error.lock() = Some(err.to_string());
+                        let message = err.to_string();
+                        // cpal's `realtime` feature reports a failed thread
+                        // promotion through this callback; playback continues
+                        // at normal priority. Warn without storing:
+                        // take_error()/has_error() signal fatal stream
+                        // failures, and a consumer must not tear down a
+                        // working stream over a scheduling downgrade.
+                        if message.contains("promote audio thread") {
+                            log::warn!(
+                                "Audio thread priority promotion failed (non-fatal): {message}"
+                            );
+                            return;
+                        }
+                        log::error!("Audio stream error: {message}");
+                        *error.lock() = Some(message);
                     },
                     None,
                 )

--- a/src/audio/synced_player.rs
+++ b/src/audio/synced_player.rs
@@ -53,7 +53,9 @@ pub struct SyncedPlayerConfig {
     pub volume: u8,
     /// Initial mute state.
     pub muted: bool,
-    /// Optional fixed cpal buffer size in frames.
+    /// Optional fixed cpal buffer size in frames. When `None`, Windows
+    /// requests a 40ms endpoint buffer (see `WINDOWS_DEFAULT_BUFFER_MS` for
+    /// the rationale) and other platforms use the cpal device default.
     pub buffer_size: Option<u32>,
 }
 
@@ -85,6 +87,37 @@ const fn static_delay_ms_to_us(delay_ms: u16) -> u64 {
         delay_ms
     };
     clamped as u64 * 1_000
+}
+
+/// Endpoint buffer requested on Windows when the caller does not override
+/// [`SyncedPlayerConfig::buffer_size`].
+///
+/// WASAPI's shared-mode default allocates two 10ms engine periods, so one
+/// late wake of the event-loop thread drains the buffer completely and the
+/// next slip starves the mixer (silence insertion — a real timeline
+/// displacement). Four periods of margin make an occasional late wake a
+/// non-event; even promoted to MMCSS the thread shares the real-time class
+/// with every other pro-audio client and will sometimes lose its slot.
+///
+/// Depth does not affect inter-device sync: the sync error is measured
+/// against padding-compensated presentation timestamps, so queued depth
+/// cancels out of the alignment math. The cost is bounded reaction latency —
+/// a track-skip flush, volume ramp, or drift correction reaches the speaker
+/// only after the already-queued frames drain.
+const WINDOWS_DEFAULT_BUFFER_MS: u32 = 40;
+
+/// Frames for [`WINDOWS_DEFAULT_BUFFER_MS`] at `sample_rate`.
+const fn windows_default_buffer_frames(sample_rate: u32) -> u32 {
+    sample_rate * WINDOWS_DEFAULT_BUFFER_MS / 1000
+}
+
+/// Endpoint buffer request when the caller does not specify one.
+fn default_buffer_size(sample_rate: u32) -> cpal::BufferSize {
+    if cfg!(target_os = "windows") {
+        cpal::BufferSize::Fixed(windows_default_buffer_frames(sample_rate))
+    } else {
+        cpal::BufferSize::Default
+    }
 }
 
 struct PlaybackQueue {
@@ -393,7 +426,9 @@ impl SyncedPlayer {
     /// The player starts at `volume` (0-100) and `muted` state. These are
     /// applied immediately — the first audio callback uses the correct gain
     /// with no ramp from a default value.
-    /// The `buffer_size` overrides cpal audio device default. If not set, the default buffer size is used.
+    /// The `buffer_size` overrides the endpoint buffer request. If not set,
+    /// Windows requests 40ms of margin (see `WINDOWS_DEFAULT_BUFFER_MS` for
+    /// the rationale) and other platforms use the cpal device default.
     pub fn new(
         format: AudioFormat,
         clock_sync: Arc<Mutex<ClockSync>>,
@@ -463,7 +498,7 @@ impl SyncedPlayer {
             sample_rate: cpal::SampleRate::from(format.sample_rate),
             buffer_size: match config.buffer_size {
                 Some(frames) => cpal::BufferSize::Fixed(frames),
-                None => cpal::BufferSize::Default,
+                None => default_buffer_size(format.sample_rate),
             },
         };
 
@@ -1390,7 +1425,8 @@ mod tests {
     // cannot run in CI.
 
     use super::{
-        static_delay_ms_to_us, PlaybackQueue, SyncedPlayer, SyncedPlayerConfig, MAX_STATIC_DELAY_MS,
+        static_delay_ms_to_us, windows_default_buffer_frames, PlaybackQueue, SyncedPlayer,
+        SyncedPlayerConfig, MAX_STATIC_DELAY_MS,
     };
     use crate::audio::{AudioBuffer, AudioFormat, Codec};
     use crate::error::Error;
@@ -1446,6 +1482,13 @@ mod tests {
             ),
             other => panic!("expected Error::Output, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_windows_default_buffer_frames_is_40ms() {
+        assert_eq!(windows_default_buffer_frames(44_100), 1_764);
+        assert_eq!(windows_default_buffer_frames(48_000), 1_920);
+        assert_eq!(windows_default_buffer_frames(192_000), 7_680);
     }
 
     #[test]

--- a/src/audio/synced_player.rs
+++ b/src/audio/synced_player.rs
@@ -388,8 +388,8 @@ struct CallbackStats {
     gate_suppressed_corrections: u64,
     /// Correction episodes started (idle -> correcting transitions, including
     /// reanchor engagements). Mirrors the "Sync correction engaged" debug
-    /// line 1:1 so the generation summary can answer "did the corrector ever
-    /// fire?" retroactively even when debug logging was off during playback.
+    /// line 1:1 so the generation summary can answer whether the corrector
+    /// ever fired, even when debug logging was off during playback.
     correction_engagements: u64,
     /// Whether the queue was below [`QUEUE_LOW_WATER_US`] at the last render.
     /// Drives the edge-triggered low/recovered debug lines.
@@ -744,15 +744,13 @@ impl SyncedPlayer {
         let mut sync_settle_logged = false;
         let mut last_callback_instant: Option<Instant> = None;
         let mut last_playback_delta_us: Option<u64> = None;
-        // Running minimum of the presentation-latency snapshot, per
-        // generation. Reanchors derive their timeline anchor from this floor
-        // rather than one wake's reading: padding noise is one-sided (see
-        // SyncErrorFilter) and flap storms cluster at exactly stream start,
-        // so a single-sample anchor is biased toward the high mode and bakes
-        // a one-period offset into the timeline that corrections must then
-        // audibly unwind. A stale floor after a mid-stream latency-regime
-        // shift costs at most a one-time period realignment — the same cost
-        // any regime shift already carries.
+        // Running minimum of the presentation-latency snapshot, reset per
+        // generation. Reanchors anchor against this floor rather than one
+        // wake's reading: padding noise is one-sided (see SyncErrorFilter),
+        // so a single sample may run a whole period high, and anchoring to it
+        // bakes that period into the timeline until corrections audibly
+        // unwind it. A stale floor after a latency-regime shift costs at most
+        // one period of realignment — no worse than the shift itself.
         let mut min_playback_delta_us = u64::MAX;
         let mut last_generation = 0u64;
         let mut stats = CallbackStats::default();
@@ -1065,19 +1063,16 @@ impl SyncedPlayer {
                                     .duration_since(playback_instant)
                                     .as_micros() as i64)
                             };
-                            // Floor-filter the measurement (windowed min):
-                            // presentation timestamps quantize to the engine
-                            // period, so a single callback's reading can sit
-                            // a whole period above the true alignment while
-                            // the endpoint FIFO plays gaplessly (see
-                            // SyncErrorFilter). Plan against the window
-                            // floor, never one wake's snapshot.
+                            // A single reading can sit a whole engine period
+                            // above true alignment while the FIFO plays
+                            // gaplessly (see SyncErrorFilter); plan against
+                            // the window floor, never one wake's snapshot.
                             let error_us = error_filter.update(raw_error_us);
                             let planned_schedule =
                                 planner.plan(error_us, sample_rate, schedule.is_correcting());
-                            // Starting a correction mutates real audio, so it
-                            // must be backed by a sustained error over a warm
-                            // filter; phantom flaps never build the streak.
+                            // Corrections mutate audible frames: engage only
+                            // on sustained evidence over a warm filter (see
+                            // EngageGate).
                             let gated_schedule = engage_gate.admit(
                                 planned_schedule,
                                 schedule.is_correcting(),
@@ -1141,10 +1136,9 @@ impl SyncedPlayer {
                                             generation,
                                         );
                                     } else {
-                                        // The floor lags upward moves, so at
-                                        // disengage `error=` can read larger
-                                        // in magnitude than the live
-                                        // `raw_error=` — expected, not a bug.
+                                        // The floor lags rises, so error= may
+                                        // read worse than raw_error= here;
+                                        // expected, not a bug.
                                         log::debug!(
                                             "Sync correction disengaged: error={:.3}ms, raw_error={:.3}ms, callback={}, generation={}",
                                             error_us as f64 / 1000.0,


### PR DESCRIPTION
This branch stops the drift corrector from mistaking timestamp measurement noise for real sync error. Audio presentation timestamps are quantized to the device period and can read a whole period late while the FIFO plays gaplessly; the old planner acted on each callback's instantaneous reading, so it "corrected" phantom errors by dropping or inserting audible frames. Corrections now plan against a ~1s windowed minimum of the error, engage only on sustained evidence, and anchor stream starts against the same floor. Windows, where the noise was acute enough to expose all this, additionally gets real thread scheduling and buffer margin.

• Cross-platform: floor-filter sync error (windowed min, ~1s) + engagement gate (~0.5s sustained over-threshold, warm filter required); resets on generation change, reanchor, clock settle, conversion loss
• Cross-platform: reanchors anchor against the running delta floor instead of one wake's possibly-inflated reading
• Windows: enable cpal's `realtime` feature (MMCSS); refused promotion is a warning, not a fatal stream error
• Windows: 40ms endpoint buffer default (engine default is 20ms = zero margin); explicit `buffer_size` still overrides
• Observability: `raw_error=` next to filtered `error=` in correction logs, `correction_engagements=` in the generation summary, exact two-period gaps logged

Tested locally as much as I can on macOS.

Refers to https://github.com/music-assistant/desktop-app/issues/126