### PR TITLE
Add ConnectionManager: multi-server arbitration with automatic goodbye

### DIFF
--- a/examples/server_initiated_metadata.rs
+++ b/examples/server_initiated_metadata.rs
@@ -1,16 +1,14 @@
-// ABOUTME: Inbound listener that announces the metadata role
-// ABOUTME: Advertises via mDNS and applies spec multi-server arbitration
+// ABOUTME: Inbound listener that announces the metadata role via mDNS and
+// ABOUTME: lets ConnectionManager handle spec multi-server arbitration
 // ABOUTME: Only partly spec-compliant: a real client would also persist the last-played server across restarts
 
 use clap::Parser;
 use mdns_sd::{ServiceDaemon, ServiceInfo};
-use sendspin::protocol::client::ConnectionGuard;
-use sendspin::protocol::messages::{ConnectionReason, GoodbyeReason, Message, PlaybackState};
+use sendspin::protocol::manager::ConnectionManager;
+use sendspin::protocol::messages::{Message, PlaybackState};
 use sendspin::ProtocolClientBuilder;
-use std::sync::Arc;
-use tokio::sync::Mutex;
 
-/// Sendspin metadata client using the inbound listener
+/// Sendspin metadata client using the managed inbound listener
 #[derive(Parser, Debug)]
 #[command(name = "server_initiated_metadata")]
 struct Args {
@@ -25,20 +23,6 @@ struct Args {
     /// Persistent client id (defaults to a random UUID)
     #[arg(short, long)]
     id: Option<String>,
-}
-
-/// The server we are currently connected to. The spec allows only one.
-struct Active {
-    peer: std::net::SocketAddr,
-    server_id: String,
-    reason: ConnectionReason,
-    guard: ConnectionGuard,
-}
-
-#[derive(Default)]
-struct State {
-    active: Option<Active>,
-    last_played: Option<String>,
 }
 
 #[tokio::main]
@@ -58,6 +42,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let port = listener.local_addr()?.port();
 
+    // The manager owns the accept loop from here: concurrent inbound
+    // handshakes, the spec keep-or-switch policy (playback beats discovery,
+    // last-played breaks discovery ties), and goodbye(another_server) to
+    // every losing connection.
+    let mut manager = ConnectionManager::new(listener);
+
     // Advertise _sendspin._tcp.local. so servers can discover and dial in.
     let daemon = ServiceDaemon::new()?;
     let service = ServiceInfo::new(
@@ -73,88 +63,36 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Listening on :{port}, advertising _sendspin._tcp.local. — waiting for server...");
 
-    let state = Arc::new(Mutex::new(State::default()));
-
-    loop {
-        let (client, peer) = listener.accept().await?;
-        let conn = client.split();
+    // Each iteration serves one arbitration winner. When the manager
+    // switches servers (or the server goes away), the connection's channels
+    // close, the inner loop ends, and next_connection() yields the
+    // replacement.
+    while let Some(mut conn) = manager.next_connection().await {
+        let peer = conn.peer;
         let server_id = conn.server_hello.server_id.clone();
-        let reason = conn.server_hello.connection_reason.clone();
-        println!("[{peer}] handshake — server_id={server_id} connection_reason={reason:?}");
+        println!(
+            "[{peer}] now serving server_id={server_id} connection_reason={:?}",
+            conn.server_hello.connection_reason
+        );
 
-        let mut st = state.lock().await;
-        if !keep_new(&st, &server_id, reason.clone()) {
-            drop(st);
-            println!("[{peer}] keeping current server — goodbye(another_server)");
-            // Spawn the goodbye so a slow flush can't block the next accept().
-            let guard = conn.guard;
-            tokio::spawn(async move {
-                guard.disconnect(GoodbyeReason::AnotherServer).await.ok();
-            });
-            continue;
-        }
-
-        // New server wins: displace the current one before taking over.
-        let displaced = st.active.take();
-        st.active = Some(Active {
-            peer,
-            server_id: server_id.clone(),
-            reason,
-            guard: conn.guard,
-        });
-        drop(st);
-
-        if let Some(old) = displaced {
-            println!(
-                "switching {} -> {server_id} — goodbye(another_server)",
-                old.server_id
-            );
-            tokio::spawn(async move {
-                old.guard
-                    .disconnect(GoodbyeReason::AnotherServer)
-                    .await
-                    .ok();
-            });
-        }
-
-        let state = Arc::clone(&state);
-        let mut messages = conn.messages;
-        tokio::spawn(async move {
-            while let Some(msg) = messages.recv().await {
-                match msg {
-                    Message::GroupUpdate(g) if g.playback_state == Some(PlaybackState::Playing) => {
-                        // A spec-compliant client would also persist this to disk here.
-                        state.lock().await.last_played = Some(server_id.clone());
-                        println!("[{peer}] playing — recorded as last played");
-                    }
-                    Message::ServerState(s) => println!("[{peer}] [METADATA] {:?}", s.metadata),
-                    other => println!("[{peer}] [MSG] {other:?}"),
+        // Only `messages` is consumed: this client negotiates just the
+        // metadata role, so the audio/artwork/visualizer receivers stay
+        // silent and can be ignored. A player would drain those too.
+        while let Some(msg) = conn.messages.recv().await {
+            match msg {
+                Message::GroupUpdate(g) if g.playback_state == Some(PlaybackState::Playing) => {
+                    // Feed the policy input back so a returning server wins
+                    // discovery ties. A spec-compliant client would also
+                    // persist this to disk here.
+                    manager.set_last_played(Some(server_id.clone()));
+                    println!("[{peer}] playing — recorded as last played");
                 }
+                Message::ServerState(s) => println!("[{peer}] [METADATA] {:?}", s.metadata),
+                other => println!("[{peer}] [MSG] {other:?}"),
             }
-            // Clear active only if this exact connection is still current.
-            let mut st = state.lock().await;
-            if st.active.as_ref().map(|a| a.peer) == Some(peer) {
-                st.active = None;
-            }
-            println!("[{peer}] disconnected");
-        });
-    }
-}
-
-/// Spec multi-server decision (README "Multiple Servers"): does the newly
-/// connected server replace the current one?
-fn keep_new(st: &State, new_id: &str, new_reason: ConnectionReason) -> bool {
-    let Some(active) = &st.active else {
-        return true;
-    };
-    match (new_reason, &active.reason) {
-        // Playback always wins.
-        (ConnectionReason::Playback, _) => true,
-        // Discovery never displaces an active playback connection.
-        (ConnectionReason::Discovery, ConnectionReason::Playback) => false,
-        // Both discovery: prefer the last played server, else keep existing.
-        (ConnectionReason::Discovery, ConnectionReason::Discovery) => {
-            st.last_played.as_deref() == Some(new_id)
         }
+        println!("[{peer}] disconnected — waiting for next server...");
     }
+
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub use audio::GainControl;
 pub use protocol::client::{Connection, ConnectionGuard, Controller, ProtocolClient, WsSender};
 pub use protocol::client_builder::ProtocolClientBuilder;
 pub use protocol::listener::ProtocolListener;
+pub use protocol::manager::{ConnectionManager, ManagedConnection, ManagerConfig};
 pub use protocol::messages::ServerHello;
 pub use sync::raw_clock::{Clock, DefaultClock};
 

--- a/src/protocol/client.rs
+++ b/src/protocol/client.rs
@@ -20,6 +20,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+use tokio::sync::watch;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::WebSocketStream;
 use tokio_tungstenite::{connect_async, tungstenite::Message as WsMessage};
@@ -622,6 +623,8 @@ pub struct ConnectionGuard {
     router_handle: Option<tokio::task::JoinHandle<()>>,
     sync_handle: Option<tokio::task::JoinHandle<()>>,
     writer_handle: Option<tokio::task::JoinHandle<()>>,
+    /// Closes when the router task exits; see [`Self::closed`].
+    closed_rx: watch::Receiver<()>,
 }
 
 impl ConnectionGuard {
@@ -656,6 +659,23 @@ impl ConnectionGuard {
 
         log::debug!("Disconnect complete");
         goodbye_result
+    }
+
+    /// Resolves once the connection is dead: the router task has exited
+    /// (peer close, transport failure, or teardown) and dropped its end of
+    /// the watch channel. Cancel-safe.
+    ///
+    /// Liveness means the *reader*. A write-side failure alone does not
+    /// fire this — on TCP it resets the read side too in short order, and
+    /// sends toward a dead writer fail fast rather than hang.
+    pub(crate) async fn closed(&mut self) {
+        // The sender never sends; the only wakeup is Err(closed).
+        let _ = self.closed_rx.changed().await;
+    }
+
+    /// Non-blocking [`Self::closed`].
+    pub(crate) fn is_closed(&self) -> bool {
+        self.closed_rx.has_changed().is_err()
     }
 }
 
@@ -803,7 +823,12 @@ impl ProtocolClient {
         let clock_sync_router = Arc::clone(&clock_sync);
         let clock_router = Arc::clone(&clock);
         let stream_state_router = Arc::clone(&stream_state);
+        // The router task owns the sender and drops it when it exits for any
+        // reason (peer close, transport error, abort), waking
+        // ConnectionGuard::closed() observers.
+        let (closed_tx, closed_rx) = watch::channel(());
         let router_handle = tokio::spawn(async move {
+            let _closed_tx = closed_tx;
             Self::message_router(
                 read,
                 audio_tx,
@@ -866,6 +891,7 @@ impl ProtocolClient {
                 router_handle: Some(router_handle),
                 sync_handle: Some(sync_handle),
                 writer_handle: Some(writer_handle),
+                closed_rx,
             },
         })
     }

--- a/src/protocol/listener.rs
+++ b/src/protocol/listener.rs
@@ -32,19 +32,24 @@ use tokio_native_tls::TlsAcceptor;
 /// [`ProtocolClientBuilder::accept`] on each, `tokio::spawn`-ing per peer.
 ///
 /// The Sendspin spec allows multiple servers to initiate connections to the
-/// same client. The keep-or-switch policy belongs to the application: read
-/// [`ProtocolClient::server_hello`] for `server_id` and `connection_reason`,
-/// compare against your persisted last-played server, and send
-/// [`GoodbyeReason::AnotherServer`] to the loser. This listener does not
-/// enforce a policy.
+/// same client. For the batteries-included path, hand this listener to
+/// [`ConnectionManager`], which runs inbound handshakes concurrently,
+/// applies the spec keep-or-switch policy ([`should_switch`]), and sends
+/// [`GoodbyeReason::AnotherServer`] to losers automatically. To run the
+/// policy yourself instead: read [`ProtocolClient::server_hello`] for
+/// `server_id` and `connection_reason`, decide with [`should_switch`]
+/// against your persisted last-played server, and send the loser's goodbye.
+/// This listener itself does not enforce a policy.
 ///
-/// Practical notes:
+/// Practical notes for the manual path:
 /// - Disconnect consumes the handle. Call [`ProtocolClient::disconnect`]
 ///   pre-split, or `connection.guard.disconnect(...)` post-split.
 /// - [`Self::accept`] is serial. If the loser's goodbye is on the critical
 ///   path, run it on a spawned task so the next inbound peer can handshake
 ///   while the previous one is tearing down.
 ///
+/// [`ConnectionManager`]: crate::protocol::manager::ConnectionManager
+/// [`should_switch`]: crate::protocol::manager::should_switch
 /// [`GoodbyeReason::AnotherServer`]: crate::protocol::messages::GoodbyeReason::AnotherServer
 pub struct ProtocolListener {
     tcp: TcpListener,
@@ -124,12 +129,7 @@ impl ProtocolListener {
     /// will block this future indefinitely, so wrap it in a timeout if
     /// untrusted peers can reach the socket.
     pub async fn accept(&self) -> Result<(ProtocolClient, SocketAddr), Error> {
-        let (tcp_stream, peer_addr) = self
-            .tcp
-            .accept()
-            .await
-            .map_err(|e| Error::Connection(format!("TCP accept failed: {e}")))?;
-        log::debug!("Accepted TCP connection from {}", peer_addr);
+        let (tcp_stream, peer_addr) = self.accept_tcp().await?;
 
         match self.handshake_and_drive(tcp_stream).await {
             Ok(client) => Ok((client, peer_addr)),
@@ -142,9 +142,28 @@ impl ProtocolListener {
         }
     }
 
-    /// Split from [`Self::accept`] so the cheap TCP accept can capture the
-    /// peer address before any fallible step (TLS, WS, protocol handshake).
-    async fn handshake_and_drive(&self, tcp_stream: TcpStream) -> Result<ProtocolClient, Error> {
+    /// Accept a raw TCP connection without starting any handshake. Split from
+    /// [`Self::accept`] so the cheap TCP accept can capture the peer address
+    /// before any fallible step, and so [`ConnectionManager`] can run the
+    /// handshake on a separate task.
+    ///
+    /// [`ConnectionManager`]: crate::protocol::manager::ConnectionManager
+    pub(crate) async fn accept_tcp(&self) -> Result<(TcpStream, SocketAddr), Error> {
+        let (tcp_stream, peer_addr) = self
+            .tcp
+            .accept()
+            .await
+            .map_err(|e| Error::Connection(format!("TCP accept failed: {e}")))?;
+        log::debug!("Accepted TCP connection from {}", peer_addr);
+        Ok((tcp_stream, peer_addr))
+    }
+
+    /// Drive TLS (if configured), the WebSocket upgrade, and the protocol
+    /// hello/state exchange over an accepted TCP stream.
+    pub(crate) async fn handshake_and_drive(
+        &self,
+        tcp_stream: TcpStream,
+    ) -> Result<ProtocolClient, Error> {
         // Branched (rather than unified through a trait-object stream)
         // so the WS handshake is monomorphized on the concrete transport.
         #[cfg(feature = "native-tls")]

--- a/src/protocol/manager.rs
+++ b/src/protocol/manager.rs
@@ -1,0 +1,585 @@
+// ABOUTME: Managed connection lifecycle: concurrent inbound handshakes, spec
+// ABOUTME: multi-server arbitration, and automatic goodbye(another_server).
+
+use crate::error::Error;
+use crate::protocol::client::{
+    ArtworkChunk, AudioChunk, Connection, ConnectionGuard, Controller, VisualizerChunk, WsSender,
+};
+use crate::protocol::listener::ProtocolListener;
+use crate::protocol::messages::{
+    ConnectionReason, GoodbyeReason, Message, PlayerState, ServerHello,
+};
+use crate::sync::ClockSync;
+use parking_lot::Mutex;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::mpsc::{self, UnboundedReceiver};
+use tokio::sync::{oneshot, Semaphore};
+use tokio::task::JoinHandle;
+
+/// The spec's multi-server arbitration rule: should the newly established
+/// `candidate` displace the `current` server?
+///
+/// [`ConnectionManager`] applies this automatically; it is public so
+/// applications running their own [`ProtocolListener::accept`] loop can make
+/// the identical decision.
+pub fn should_switch(
+    current: &ServerHello,
+    candidate: &ServerHello,
+    last_played: Option<&str>,
+) -> bool {
+    // Matched as (candidate, current) — reverse of the parameter order —
+    // so the new server reads first in each arm.
+    match (&candidate.connection_reason, &current.connection_reason) {
+        (ConnectionReason::Playback, _) => true,
+        (ConnectionReason::Discovery, ConnectionReason::Playback) => false,
+        (ConnectionReason::Discovery, ConnectionReason::Discovery) => {
+            matches!(last_played, Some(lp) if candidate.server_id == lp)
+        }
+    }
+}
+
+/// Default [`ManagerConfig::establish_timeout`]
+pub const DEFAULT_ESTABLISH_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Default [`ManagerConfig::max_concurrent_handshakes`]
+pub const DEFAULT_MAX_CONCURRENT_HANDSHAKES: usize = 2;
+
+/// Default [`ManagerConfig::goodbye_timeout`].
+pub const DEFAULT_GOODBYE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Tuning for [`ConnectionManager`].
+#[derive(Debug, Clone)]
+pub struct ManagerConfig {
+    /// Deadline for an inbound connection to complete TLS + WebSocket +
+    /// protocol handshake, measured from TCP accept. Peers that stall are
+    /// dropped. Default: [`DEFAULT_ESTABLISH_TIMEOUT`].
+    pub establish_timeout: Duration,
+    /// Maximum number of inbound connections concurrently working through
+    /// their handshake. Surplus peers wait in the TCP accept backlog rather
+    /// than being rejected. Values below 1 are clamped to 1. Default:
+    /// [`DEFAULT_MAX_CONCURRENT_HANDSHAKES`].
+    pub max_concurrent_handshakes: usize,
+    /// Deadline for flushing `client/goodbye` to a losing, displaced, or
+    /// disconnected server. On elapse the connection is torn down without
+    /// confirmation — a peer that stops reading would otherwise pin the
+    /// flush (and its connection's tasks and socket) until the OS TCP
+    /// timeout. Default: [`DEFAULT_GOODBYE_TIMEOUT`].
+    pub goodbye_timeout: Duration,
+}
+
+impl Default for ManagerConfig {
+    fn default() -> Self {
+        Self {
+            establish_timeout: DEFAULT_ESTABLISH_TIMEOUT,
+            max_concurrent_handshakes: DEFAULT_MAX_CONCURRENT_HANDSHAKES,
+            goodbye_timeout: DEFAULT_GOODBYE_TIMEOUT,
+        }
+    }
+}
+
+/// Identical in shape to [`Connection`] except the [`ConnectionGuard`] stays
+/// with the manager: the manager must retain teardown authority so it can
+/// send `client/goodbye (another_server)` to a displaced incumbent.
+pub struct ManagedConnection {
+    /// JSON protocol messages from the server.
+    pub messages: UnboundedReceiver<Message>,
+    /// Audio chunks from the server.
+    pub audio: UnboundedReceiver<AudioChunk>,
+    /// Artwork chunks from the server.
+    pub artwork: UnboundedReceiver<ArtworkChunk>,
+    /// Visualizer chunks from the server.
+    pub visualizer: UnboundedReceiver<VisualizerChunk>,
+    /// Clock synchronization state. Fresh per connection: audio components
+    /// built around it (e.g. `SyncedPlayer`) must be rebuilt per connection.
+    pub clock_sync: Arc<Mutex<ClockSync>>,
+    /// Sender for writing messages to the server.
+    pub sender: WsSender,
+    /// Controller handle, if the server granted the `controller@v1` role.
+    pub controller: Option<Controller>,
+    /// The `server/hello` received during handshake.
+    pub server_hello: ServerHello,
+    /// Peer address of the winning connection.
+    pub peer: SocketAddr,
+}
+
+impl ManagedConnection {
+    /// See [`WsSender::enter_external_source`].
+    pub async fn enter_external_source(&self) -> Result<(), Error> {
+        self.sender.enter_external_source().await
+    }
+
+    /// See [`WsSender::exit_external_source`].
+    pub async fn exit_external_source(&self, player: Option<PlayerState>) -> Result<(), Error> {
+        self.sender.exit_external_source(player).await
+    }
+}
+
+/// Commands from the [`ConnectionManager`] handle to its driver task.
+enum Command {
+    SetLastPlayed(Option<String>),
+    Disconnect(GoodbyeReason, oneshot::Sender<Result<(), Error>>),
+}
+
+/// The guard stays here so the driver keeps teardown authority over a server
+/// the application is still consuming.
+struct Incumbent {
+    guard: ConnectionGuard,
+    server_hello: ServerHello,
+    peer: SocketAddr,
+}
+
+/// Owns a [`ProtocolListener`] and drives the full multi-server connection
+/// lifecycle:
+///
+/// - Inbound peers handshake **concurrently** (bounded by
+///   [`ManagerConfig::max_concurrent_handshakes`]) with an establish
+///   deadline, so a stalling peer can neither block other servers nor occupy
+///   a slot forever. A connection is never surfaced before its handshake
+///   completes.
+/// - Each established connection is arbitrated against the incumbent with
+///   [`should_switch`]. The loser — displaced incumbent or rejected
+///   newcomer — is automatically sent `client/goodbye (another_server)`.
+/// - Winners are yielded from [`Self::next_connection`]. When a winner is
+///   displaced (or its server goes away), its channels close and the next
+///   call yields the replacement.
+///
+/// Last-played preference is a policy **input**: persist the server ID in
+/// your application and feed it back via [`Self::set_last_played`] (the SDK
+/// does not persist state as there is no cross-platform cross-app way to do
+/// so cleanly).
+///
+/// Dropping the manager aborts the accept loop and the current connection
+/// **without** a goodbye; call [`Self::disconnect`] first for a graceful
+/// shutdown.
+///
+/// ```no_run
+/// # use sendspin::{ConnectionManager, ProtocolClientBuilder};
+/// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+/// let listener = ProtocolClientBuilder::builder()
+///     .client_id(uuid::Uuid::new_v4().to_string())
+///     .name("Kitchen Speaker".to_string())
+///     .build()
+///     .listen("0.0.0.0:8927")
+///     .await?;
+/// let mut manager = ConnectionManager::new(listener);
+/// while let Some(conn) = manager.next_connection().await {
+///     // Serve conn until its channels close, then loop for its successor.
+/// }
+/// # Ok(()) }
+/// ```
+///
+/// See `examples/server_initiated_metadata.rs` for a complete program.
+pub struct ConnectionManager {
+    conn_rx: mpsc::UnboundedReceiver<ManagedConnection>,
+    cmd_tx: mpsc::UnboundedSender<Command>,
+    accept_task: JoinHandle<()>,
+    driver_task: JoinHandle<()>,
+    local_addr: Option<SocketAddr>,
+}
+
+impl std::fmt::Debug for ConnectionManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConnectionManager")
+            .field("local_addr", &self.local_addr)
+            .finish()
+    }
+}
+
+impl ConnectionManager {
+    /// Manage `listener` with default [`ManagerConfig`].
+    pub fn new(listener: ProtocolListener) -> Self {
+        Self::with_config(listener, ManagerConfig::default())
+    }
+
+    /// Manage `listener` with explicit tuning.
+    pub fn with_config(listener: ProtocolListener, mut config: ManagerConfig) -> Self {
+        // Zero handshake slots would deadlock the accept loop; clamp once
+        // here so every downstream use sees the same normalized value.
+        config.max_concurrent_handshakes = config.max_concurrent_handshakes.max(1);
+
+        let local_addr = listener.local_addr().ok();
+        // Bounded: pairs with the handshake slots to stop admission when the
+        // arbitration driver stalls (see accept_loop).
+        let (established_tx, established_rx) =
+            mpsc::channel::<(Connection, SocketAddr)>(config.max_concurrent_handshakes);
+        let (conn_tx, conn_rx) = mpsc::unbounded_channel();
+        let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
+
+        let goodbye_timeout = config.goodbye_timeout;
+        let accept_task = tokio::spawn(accept_loop(Arc::new(listener), established_tx, config));
+        let driver_task = tokio::spawn(driver(established_rx, conn_tx, cmd_rx, goodbye_timeout));
+
+        Self {
+            conn_rx,
+            cmd_tx,
+            accept_task,
+            driver_task,
+            local_addr,
+        }
+    }
+
+    /// Wait for the next connection to win arbitration. Cancel-safe.
+    /// Returns `None` only if the internal driver has stopped (it does not
+    /// stop in normal operation).
+    ///
+    /// Winners queue unboundedly, so consume promptly. An entry displaced
+    /// before you received it arrives with already-closed channels — drain
+    /// it and loop again.
+    pub async fn next_connection(&mut self) -> Option<ManagedConnection> {
+        self.conn_rx.recv().await
+    }
+
+    /// Set (or clear, with `None`) the last-played server ID used to break
+    /// ties between two `discovery` connections. Persisting this across runs
+    /// is the application's responsibility.
+    pub fn set_last_played(&self, server_id: Option<String>) {
+        // Send failure means the driver is gone; arbitration is moot then.
+        let _ = self.cmd_tx.send(Command::SetLastPlayed(server_id));
+    }
+
+    /// Gracefully disconnect the current server, sending `client/goodbye`
+    /// with `reason` and awaiting the flush (bounded by
+    /// [`ManagerConfig::goodbye_timeout`]). No-op `Ok(())` when no server
+    /// is connected. The manager keeps listening; a later inbound server
+    /// is yielded from [`Self::next_connection`] as usual.
+    pub async fn disconnect(&self, reason: GoodbyeReason) -> Result<(), Error> {
+        let (ack_tx, ack_rx) = oneshot::channel();
+        self.cmd_tx
+            .send(Command::Disconnect(reason, ack_tx))
+            .map_err(|_| Error::Connection("connection manager stopped".to_string()))?;
+        ack_rx
+            .await
+            .map_err(|_| Error::Connection("connection manager stopped".to_string()))?
+    }
+
+    /// Local bound address of the underlying listener, if it was available
+    /// at construction time.
+    pub fn local_addr(&self) -> Option<SocketAddr> {
+        self.local_addr
+    }
+}
+
+impl Drop for ConnectionManager {
+    fn drop(&mut self) {
+        // Abrupt teardown: aborting the driver drops the incumbent's guard,
+        // which aborts its background tasks without a goodbye. Graceful
+        // shutdown is `disconnect(...)` before drop.
+        self.accept_task.abort();
+        self.driver_task.abort();
+    }
+}
+
+/// Admit TCP peers as slots allow and run each handshake on its own task
+/// under the establish deadline. Surplus peers wait in the TCP accept backlog
+/// rather than being rejected with a goodbye.
+///
+/// A task holds its slot through the `established_tx` send, so a stalled
+/// arbitration driver stops admission instead of accumulating established
+/// connections. Tasks live in a `JoinSet` so aborting this loop (manager
+/// drop) aborts in-flight handshakes, releasing their sockets — and the
+/// listener's port — promptly instead of after `establish_timeout`.
+async fn accept_loop(
+    listener: Arc<ProtocolListener>,
+    established_tx: mpsc::Sender<(Connection, SocketAddr)>,
+    config: ManagerConfig,
+) {
+    let slots = Arc::new(Semaphore::new(config.max_concurrent_handshakes));
+    let mut handshakes = tokio::task::JoinSet::new();
+    loop {
+        while handshakes.try_join_next().is_some() {}
+
+        let permit = Arc::clone(&slots)
+            .acquire_owned()
+            .await
+            .expect("handshake semaphore is never closed");
+
+        let (tcp, peer) = match listener.accept_tcp().await {
+            Ok(accepted) => accepted,
+            Err(e) => {
+                // Accept errors (e.g. fd exhaustion) are usually transient;
+                // pause briefly instead of spinning or dying.
+                log::warn!("ConnectionManager accept failed: {e}");
+                drop(permit);
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                continue;
+            }
+        };
+
+        let listener = Arc::clone(&listener);
+        let established_tx = established_tx.clone();
+        let deadline = config.establish_timeout;
+        handshakes.spawn(async move {
+            // Hold the handshake slot for the lifetime of the attempt.
+            let _permit = permit;
+            match tokio::time::timeout(deadline, listener.handshake_and_drive(tcp)).await {
+                Ok(Ok(client)) => {
+                    // Driver gone (manager dropped): the connection is
+                    // dropped here and its guard aborts its tasks.
+                    let _ = established_tx.send((client.split(), peer)).await;
+                }
+                Ok(Err(e)) => log::warn!("Inbound handshake from {peer} failed: {e}"),
+                Err(_) => log::warn!(
+                    "Inbound connection from {peer} did not establish within {deadline:?}; dropping"
+                ),
+            }
+        });
+    }
+}
+
+/// Arbitration driver: single owner of the incumbent connection's guard and
+/// the last-played policy input. All lifecycle transitions happen here.
+async fn driver(
+    mut established_rx: mpsc::Receiver<(Connection, SocketAddr)>,
+    conn_tx: mpsc::UnboundedSender<ManagedConnection>,
+    mut cmd_rx: mpsc::UnboundedReceiver<Command>,
+    goodbye_timeout: Duration,
+) {
+    let mut last_played: Option<String> = None;
+    let mut current: Option<Incumbent> = None;
+    // Goodbye flushes run in a JoinSet rather than detached, so aborting the
+    // driver (manager drop) also aborts any still-wedged flush.
+    let mut goodbyes = tokio::task::JoinSet::new();
+
+    loop {
+        while goodbyes.try_join_next().is_some() {}
+
+        // Resolves when the incumbent's reader task ends (server closed the
+        // socket or transport failure); pends forever when there is none.
+        let incumbent_closed = async {
+            match current.as_mut() {
+                Some(inc) => inc.guard.closed().await,
+                None => std::future::pending().await,
+            }
+        };
+
+        tokio::select! {
+            established = established_rx.recv() => {
+                let Some((conn, peer)) = established else {
+                    // Accept loop is gone; only possible when the manager
+                    // handle was dropped, which also aborts this task.
+                    break;
+                };
+                arbitrate(
+                    &mut current,
+                    conn,
+                    peer,
+                    last_played.as_deref(),
+                    &conn_tx,
+                    &mut goodbyes,
+                    goodbye_timeout,
+                );
+            }
+            _ = incumbent_closed => {
+                let inc = current.take().expect("closed() only fires with an incumbent");
+                log::info!(
+                    "Server {} ({}) disconnected; awaiting next server",
+                    inc.server_hello.server_id,
+                    inc.peer
+                );
+            }
+            cmd = cmd_rx.recv() => {
+                match cmd {
+                    None => break, // ConnectionManager handle dropped.
+                    Some(Command::SetLastPlayed(id)) => last_played = id,
+                    Some(Command::Disconnect(reason, ack)) => {
+                        match current.take() {
+                            // Peer already dead: a goodbye is moot, and
+                            // flushing one at a dead socket would turn a
+                            // successful teardown into a spurious error.
+                            Some(inc) if inc.guard.is_closed() => {
+                                let _ = ack.send(Ok(()));
+                            }
+                            // Off the driver task so a slow flush can't
+                            // stall arbitration; the caller still gets the
+                            // real result via the ack.
+                            Some(inc) => {
+                                goodbyes.spawn(async move {
+                                    let _ = ack.send(
+                                        flush_goodbye(inc.guard, reason, goodbye_timeout).await,
+                                    );
+                                });
+                            }
+                            None => {
+                                let _ = ack.send(Ok(()));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Flush `client/goodbye` with a deadline: a peer that stops reading must
+/// not pin the flush — and the connection's tasks and socket — until the OS
+/// TCP timeout. On elapse the guard is dropped, aborting the connection.
+async fn flush_goodbye(
+    guard: ConnectionGuard,
+    reason: GoodbyeReason,
+    deadline: Duration,
+) -> Result<(), Error> {
+    match tokio::time::timeout(deadline, guard.disconnect(reason.clone())).await {
+        Ok(result) => result,
+        Err(_) => {
+            log::warn!("client/goodbye ({reason:?}) flush timed out; connection aborted");
+            Err(Error::Connection(
+                "client/goodbye flush timed out; connection aborted".to_string(),
+            ))
+        }
+    }
+}
+
+/// Apply [`should_switch`] to a freshly established connection: promote it
+/// (goodbying any displaced incumbent) or reject it with a goodbye.
+fn arbitrate(
+    current: &mut Option<Incumbent>,
+    conn: Connection,
+    peer: SocketAddr,
+    last_played: Option<&str>,
+    conn_tx: &mpsc::UnboundedSender<ManagedConnection>,
+    goodbyes: &mut tokio::task::JoinSet<()>,
+    goodbye_timeout: Duration,
+) {
+    // The incumbent may have died in the same instant this connection
+    // established, and the select loop can deliver the establishment first.
+    // A dead incumbent must not reject a live server, so check liveness
+    // before applying policy. No goodbye owed: the transport is gone.
+    if current.as_ref().is_some_and(|inc| inc.guard.is_closed()) {
+        let dead = current.take().expect("checked Some above");
+        log::info!(
+            "Server {} ({}) already disconnected; arbitration proceeds without it",
+            dead.server_hello.server_id,
+            dead.peer
+        );
+    }
+
+    if let Some(inc) = current.as_ref() {
+        if !should_switch(&inc.server_hello, &conn.server_hello, last_played) {
+            log::info!(
+                "Keeping server {} — rejecting {} ({peer}) with goodbye(another_server)",
+                inc.server_hello.server_id,
+                conn.server_hello.server_id,
+            );
+            // Spawned so a slow flush can't stall arbitration; dropping the
+            // rest of `conn` closes its channels.
+            goodbyes.spawn(async move {
+                let _ =
+                    flush_goodbye(conn.guard, GoodbyeReason::AnotherServer, goodbye_timeout).await;
+            });
+            return;
+        }
+
+        let displaced = current.take().expect("checked Some above");
+        log::info!(
+            "Switching {} -> {} — goodbye(another_server) to displaced server",
+            displaced.server_hello.server_id,
+            conn.server_hello.server_id,
+        );
+        goodbyes.spawn(async move {
+            let _ = flush_goodbye(
+                displaced.guard,
+                GoodbyeReason::AnotherServer,
+                goodbye_timeout,
+            )
+            .await;
+        });
+    } else {
+        log::info!(
+            "Server {} ({peer}) connected (reason: {:?})",
+            conn.server_hello.server_id,
+            conn.server_hello.connection_reason,
+        );
+    }
+
+    let Connection {
+        messages,
+        audio,
+        artwork,
+        visualizer,
+        clock_sync,
+        sender,
+        controller,
+        server_hello,
+        guard,
+    } = conn;
+
+    *current = Some(Incumbent {
+        guard,
+        server_hello: server_hello.clone(),
+        peer,
+    });
+
+    // Receiver dropped means the manager handle is gone; the driver will
+    // exit via its command channel shortly after.
+    let _ = conn_tx.send(ManagedConnection {
+        messages,
+        audio,
+        artwork,
+        visualizer,
+        clock_sync,
+        sender,
+        controller,
+        server_hello,
+        peer,
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hello(server_id: &str, reason: ConnectionReason) -> ServerHello {
+        ServerHello {
+            server_id: server_id.to_string(),
+            name: format!("{server_id} name"),
+            version: 1,
+            active_roles: vec![],
+            connection_reason: reason,
+        }
+    }
+
+    // ConnectionManager::should_switch_to_new_server.
+
+    #[test]
+    fn playback_candidate_always_wins() {
+        let current = hello("a", ConnectionReason::Playback);
+        let candidate = hello("b", ConnectionReason::Playback);
+        assert!(should_switch(&current, &candidate, None));
+
+        let current = hello("a", ConnectionReason::Discovery);
+        assert!(should_switch(&current, &candidate, None));
+
+        // Even when the incumbent is the last-played server.
+        assert!(should_switch(&current, &candidate, Some("a")));
+    }
+
+    #[test]
+    fn discovery_never_displaces_playback() {
+        let current = hello("a", ConnectionReason::Playback);
+        let candidate = hello("b", ConnectionReason::Discovery);
+        assert!(!should_switch(&current, &candidate, None));
+        // Even when the candidate is the last-played server.
+        assert!(!should_switch(&current, &candidate, Some("b")));
+    }
+
+    #[test]
+    fn both_discovery_prefers_last_played() {
+        let current = hello("a", ConnectionReason::Discovery);
+        let candidate = hello("b", ConnectionReason::Discovery);
+
+        assert!(should_switch(&current, &candidate, Some("b")));
+        assert!(!should_switch(&current, &candidate, Some("a")));
+    }
+
+    #[test]
+    fn both_discovery_defaults_to_keep() {
+        let current = hello("a", ConnectionReason::Discovery);
+        let candidate = hello("b", ConnectionReason::Discovery);
+
+        assert!(!should_switch(&current, &candidate, None));
+        // Last-played matches neither: keep.
+        assert!(!should_switch(&current, &candidate, Some("c")));
+    }
+}

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -7,9 +7,12 @@ pub mod client;
 pub mod client_builder;
 /// Inbound WebSocket acceptor for server-initiated connections
 pub mod listener;
+/// Managed connection lifecycle: multi-server arbitration and auto-goodbye
+pub mod manager;
 /// Protocol message type definitions and serialization
 pub mod messages;
 
 pub use client::{Connection, ConnectionGuard, Controller, WsSender};
 pub use listener::ProtocolListener;
+pub use manager::{should_switch, ConnectionManager, ManagedConnection, ManagerConfig};
 pub use messages::Message;

--- a/tests/connection_manager.rs
+++ b/tests/connection_manager.rs
@@ -1,0 +1,381 @@
+// ABOUTME: Integration tests for ConnectionManager — concurrent inbound
+// ABOUTME: handshakes, multi-server arbitration, and automatic goodbyes.
+
+use futures_util::{SinkExt, StreamExt};
+use sendspin::protocol::manager::{ConnectionManager, ManagerConfig};
+use sendspin::protocol::messages::{ConnectionReason, GoodbyeReason, Message, ServerHello};
+use sendspin::ProtocolClientBuilder;
+use std::time::Duration;
+use tokio::time::timeout;
+use tokio_tungstenite::{connect_async, tungstenite::Message as WsMessage};
+
+/// A test protocol-server: dials the manager's listener, answers
+/// `client/hello` with a `server/hello` carrying the given identity, and
+/// forwards every subsequent text frame to `messages`.
+struct Peer {
+    messages: tokio::sync::mpsc::UnboundedReceiver<String>,
+    /// Send raw frames to the client (unused by most tests; keeps write half alive).
+    _writer: tokio::sync::mpsc::UnboundedSender<WsMessage>,
+    _tasks: Vec<tokio::task::JoinHandle<()>>,
+}
+
+async fn connect_peer(url: &str, server_id: &str, reason: ConnectionReason) -> Peer {
+    let (ws, _) = connect_async(url).await.expect("WS connect failed");
+    let (mut write, mut read) = ws.split();
+
+    let hello_text = match read.next().await.expect("no hello").expect("ws error") {
+        WsMessage::Text(t) => t,
+        other => panic!("expected text client/hello, got {other:?}"),
+    };
+    let parsed: Message = serde_json::from_str(&hello_text).expect("client/hello must deserialize");
+    assert!(
+        matches!(parsed, Message::ClientHello(_)),
+        "first message should be client/hello"
+    );
+
+    let server_hello = serde_json::to_string(&Message::ServerHello(ServerHello {
+        server_id: server_id.to_string(),
+        name: format!("{server_id} name"),
+        version: 1,
+        active_roles: vec![],
+        connection_reason: reason,
+    }))
+    .unwrap();
+    write
+        .send(WsMessage::Text(server_hello.into()))
+        .await
+        .expect("send server/hello");
+
+    let (msg_tx, msg_rx) = tokio::sync::mpsc::unbounded_channel();
+    let reader = tokio::spawn(async move {
+        while let Some(Ok(msg)) = read.next().await {
+            let text = match msg {
+                WsMessage::Text(t) => t,
+                WsMessage::Close(_) => break,
+                _ => continue,
+            };
+            if msg_tx.send(text.to_string()).is_err() {
+                break;
+            }
+        }
+    });
+
+    let (out_tx, mut out_rx) = tokio::sync::mpsc::unbounded_channel::<WsMessage>();
+    let writer = tokio::spawn(async move {
+        while let Some(frame) = out_rx.recv().await {
+            if write.send(frame).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    Peer {
+        messages: msg_rx,
+        _writer: out_tx,
+        _tasks: vec![reader, writer],
+    }
+}
+
+async fn manager(config: Option<ManagerConfig>) -> (String, ConnectionManager) {
+    let builder = ProtocolClientBuilder::builder()
+        .client_id("test-managed-client".to_string())
+        .name("Managed Client".to_string())
+        .build();
+    let listener = builder.listen("127.0.0.1:0").await.expect("listen failed");
+    let mgr = match config {
+        Some(c) => ConnectionManager::with_config(listener, c),
+        None => ConnectionManager::new(listener),
+    };
+    let addr = mgr.local_addr().expect("local_addr");
+    (format!("ws://{addr}"), mgr)
+}
+
+/// Waits until the peer receives `client/goodbye` and returns its reason;
+/// panics if the peer goes quiet for 2s first.
+async fn expect_goodbye(peer: &mut Peer) -> GoodbyeReason {
+    loop {
+        let text = timeout(Duration::from_secs(2), peer.messages.recv())
+            .await
+            .expect("timed out waiting for client/goodbye")
+            .expect("peer channel closed without a goodbye");
+        if let Ok(Message::ClientGoodbye(g)) = serde_json::from_str::<Message>(&text) {
+            return g.reason;
+        }
+    }
+}
+
+/// Asserts the peer receives no `client/goodbye` within `window`.
+async fn assert_no_goodbye(peer: &mut Peer, window: Duration) {
+    let deadline = tokio::time::Instant::now() + window;
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        match timeout(remaining, peer.messages.recv()).await {
+            Err(_) => return, // window elapsed quietly
+            Ok(None) => panic!("peer connection closed unexpectedly"),
+            Ok(Some(text)) => {
+                if matches!(
+                    serde_json::from_str::<Message>(&text),
+                    Ok(Message::ClientGoodbye(_))
+                ) {
+                    panic!("unexpected client/goodbye");
+                }
+            }
+        }
+    }
+}
+
+/// Drains a yielded connection's message channel until it closes; panics if
+/// it stays open past 2s.
+async fn expect_channels_close(conn: &mut sendspin::ManagedConnection) {
+    loop {
+        match timeout(Duration::from_secs(2), conn.messages.recv()).await {
+            Ok(None) => return,
+            Ok(Some(_)) => continue,
+            Err(_) => panic!("displaced connection's channels never closed"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_first_server_is_promoted() {
+    let (url, mut mgr) = manager(None).await;
+
+    let _peer = connect_peer(&url, "server-a", ConnectionReason::Discovery).await;
+
+    let conn = timeout(Duration::from_secs(5), mgr.next_connection())
+        .await
+        .expect("next_connection timed out")
+        .expect("manager stopped");
+    assert_eq!(conn.server_hello.server_id, "server-a");
+    assert_eq!(
+        conn.server_hello.connection_reason,
+        ConnectionReason::Discovery
+    );
+    assert!(conn.peer.ip().is_loopback());
+}
+
+#[tokio::test]
+async fn test_playback_displaces_discovery_incumbent() {
+    let (url, mut mgr) = manager(None).await;
+
+    let mut peer_a = connect_peer(&url, "server-a", ConnectionReason::Discovery).await;
+    let mut conn_a = mgr.next_connection().await.expect("manager stopped");
+    assert_eq!(conn_a.server_hello.server_id, "server-a");
+
+    let _peer_b = connect_peer(&url, "server-b", ConnectionReason::Playback).await;
+
+    // The displaced incumbent gets an automatic goodbye(another_server)...
+    assert_eq!(
+        expect_goodbye(&mut peer_a).await,
+        GoodbyeReason::AnotherServer
+    );
+    // ...the app sees its channels close...
+    expect_channels_close(&mut conn_a).await;
+    // ...and the winner is yielded.
+    let conn_b = timeout(Duration::from_secs(5), mgr.next_connection())
+        .await
+        .expect("next_connection timed out")
+        .expect("manager stopped");
+    assert_eq!(conn_b.server_hello.server_id, "server-b");
+}
+
+#[tokio::test]
+async fn test_discovery_never_displaces_playback() {
+    let (url, mut mgr) = manager(None).await;
+
+    let mut peer_a = connect_peer(&url, "server-a", ConnectionReason::Playback).await;
+    let conn_a = mgr.next_connection().await.expect("manager stopped");
+    assert_eq!(conn_a.server_hello.server_id, "server-a");
+
+    // Even the last-played server cannot displace active playback.
+    mgr.set_last_played(Some("server-b".to_string()));
+    let mut peer_b = connect_peer(&url, "server-b", ConnectionReason::Discovery).await;
+
+    // The rejected newcomer gets the goodbye; the incumbent stays quiet.
+    assert_eq!(
+        expect_goodbye(&mut peer_b).await,
+        GoodbyeReason::AnotherServer
+    );
+    assert_no_goodbye(&mut peer_a, Duration::from_millis(300)).await;
+}
+
+#[tokio::test]
+async fn test_last_played_breaks_discovery_tie() {
+    let (url, mut mgr) = manager(None).await;
+    mgr.set_last_played(Some("server-b".to_string()));
+
+    let mut peer_a = connect_peer(&url, "server-a", ConnectionReason::Discovery).await;
+    let conn_a = mgr.next_connection().await.expect("manager stopped");
+    assert_eq!(conn_a.server_hello.server_id, "server-a");
+
+    let _peer_b = connect_peer(&url, "server-b", ConnectionReason::Discovery).await;
+    assert_eq!(
+        expect_goodbye(&mut peer_a).await,
+        GoodbyeReason::AnotherServer
+    );
+    let conn_b = timeout(Duration::from_secs(5), mgr.next_connection())
+        .await
+        .expect("next_connection timed out")
+        .expect("manager stopped");
+    assert_eq!(conn_b.server_hello.server_id, "server-b");
+}
+
+#[tokio::test]
+async fn test_discovery_tie_defaults_to_keep() {
+    let (url, mut mgr) = manager(None).await;
+
+    let mut peer_a = connect_peer(&url, "server-a", ConnectionReason::Discovery).await;
+    let conn_a = mgr.next_connection().await.expect("manager stopped");
+    assert_eq!(conn_a.server_hello.server_id, "server-a");
+
+    let mut peer_b = connect_peer(&url, "server-b", ConnectionReason::Discovery).await;
+    assert_eq!(
+        expect_goodbye(&mut peer_b).await,
+        GoodbyeReason::AnotherServer
+    );
+    assert_no_goodbye(&mut peer_a, Duration::from_millis(300)).await;
+}
+
+#[tokio::test]
+async fn test_incumbent_death_frees_slot() {
+    let (url, mut mgr) = manager(None).await;
+
+    let peer_a = connect_peer(&url, "server-a", ConnectionReason::Discovery).await;
+    let mut conn_a = mgr.next_connection().await.expect("manager stopped");
+    assert_eq!(conn_a.server_hello.server_id, "server-a");
+
+    // Server A goes away (socket closed, no goodbye exchange).
+    drop(peer_a);
+    expect_channels_close(&mut conn_a).await;
+
+    // A plain discovery connection (not last-played) must now be promoted:
+    // the dead incumbent may no longer win arbitration.
+    let mut peer_b = connect_peer(&url, "server-b", ConnectionReason::Discovery).await;
+    let conn_b = timeout(Duration::from_secs(5), mgr.next_connection())
+        .await
+        .expect("next_connection timed out")
+        .expect("manager stopped");
+    assert_eq!(conn_b.server_hello.server_id, "server-b");
+    assert_no_goodbye(&mut peer_b, Duration::from_millis(300)).await;
+}
+
+#[tokio::test]
+async fn test_disconnect_sends_goodbye_and_keeps_listening() {
+    let (url, mut mgr) = manager(None).await;
+
+    // Disconnect with no incumbent is a no-op Ok.
+    mgr.disconnect(GoodbyeReason::UserRequest)
+        .await
+        .expect("no-op disconnect");
+
+    let mut peer_a = connect_peer(&url, "server-a", ConnectionReason::Playback).await;
+    let mut conn_a = mgr.next_connection().await.expect("manager stopped");
+
+    mgr.disconnect(GoodbyeReason::UserRequest)
+        .await
+        .expect("disconnect");
+    assert_eq!(
+        expect_goodbye(&mut peer_a).await,
+        GoodbyeReason::UserRequest
+    );
+    expect_channels_close(&mut conn_a).await;
+
+    // The manager keeps listening: a new server can still connect.
+    let _peer_b = connect_peer(&url, "server-b", ConnectionReason::Discovery).await;
+    let conn_b = timeout(Duration::from_secs(5), mgr.next_connection())
+        .await
+        .expect("next_connection timed out")
+        .expect("manager stopped");
+    assert_eq!(conn_b.server_hello.server_id, "server-b");
+}
+
+#[tokio::test]
+async fn test_playback_displaces_playback() {
+    let (url, mut mgr) = manager(None).await;
+
+    let mut peer_a = connect_peer(&url, "server-a", ConnectionReason::Playback).await;
+    let conn_a = mgr.next_connection().await.expect("manager stopped");
+    assert_eq!(conn_a.server_hello.server_id, "server-a");
+
+    // Newest playback intent wins even against a playback incumbent.
+    let _peer_b = connect_peer(&url, "server-b", ConnectionReason::Playback).await;
+    assert_eq!(
+        expect_goodbye(&mut peer_a).await,
+        GoodbyeReason::AnotherServer
+    );
+    let conn_b = timeout(Duration::from_secs(5), mgr.next_connection())
+        .await
+        .expect("next_connection timed out")
+        .expect("manager stopped");
+    assert_eq!(conn_b.server_hello.server_id, "server-b");
+}
+
+#[tokio::test]
+async fn test_drop_aborts_inflight_handshake_promptly() {
+    // A long establish deadline: without abort-on-drop tracking, the
+    // in-flight handshake task would keep the peer's TCP stream (and the
+    // listener) alive for the full 30s after the manager is gone.
+    let (url, mgr) = manager(Some(ManagerConfig {
+        establish_timeout: Duration::from_secs(30),
+        max_concurrent_handshakes: 1,
+        ..ManagerConfig::default()
+    }))
+    .await;
+
+    let addr = url.strip_prefix("ws://").unwrap().to_string();
+    let stalled = tokio::net::TcpStream::connect(&addr)
+        .await
+        .expect("raw TCP connect");
+    // Let the accept loop admit the stalled peer into its handshake slot.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    drop(mgr);
+
+    // The aborted handshake task must drop the TCP stream promptly: the
+    // stalled peer observes EOF/reset well before the 30s deadline.
+    let mut buf = [0u8; 1];
+    let read = timeout(Duration::from_secs(2), async {
+        use tokio::io::AsyncReadExt;
+        let mut stream = stalled;
+        stream.read(&mut buf).await
+    })
+    .await;
+    match read {
+        Ok(Ok(0)) => {}  // clean EOF
+        Ok(Err(_)) => {} // reset — also fine
+        Ok(Ok(n)) => panic!("unexpected {n} bytes from dropped manager"),
+        Err(_) => panic!("handshake task kept the connection alive after manager drop"),
+    }
+}
+
+#[tokio::test]
+async fn test_stalled_handshake_is_reaped_and_frees_slot() {
+    // One handshake slot and a short establish deadline: a peer that
+    // connects and stalls must be reaped so the next peer can establish.
+    let (url, mut mgr) = manager(Some(ManagerConfig {
+        establish_timeout: Duration::from_millis(300),
+        max_concurrent_handshakes: 1,
+        ..ManagerConfig::default()
+    }))
+    .await;
+
+    // Raw TCP connect that never speaks WebSocket, occupying the only slot.
+    let addr = url.strip_prefix("ws://").unwrap().to_string();
+    let stalled = tokio::net::TcpStream::connect(&addr)
+        .await
+        .expect("raw TCP connect");
+
+    // Give the accept loop time to admit the stalled peer into its slot.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // A real server connecting behind it must still establish once the
+    // stalled peer is reaped at the deadline.
+    let _peer = connect_peer(&url, "server-a", ConnectionReason::Playback).await;
+    let conn = timeout(Duration::from_secs(5), mgr.next_connection())
+        .await
+        .expect("next_connection timed out — stalled peer was never reaped")
+        .expect("manager stopped");
+    assert_eq!(conn.server_hello.server_id, "server-a");
+
+    drop(stalled);
+}


### PR DESCRIPTION
Closes the SDK-side gaps from issue #53, modeled on sendspin-cpp's ConnectionManager (its nursery/handoff design translated to tokio tasks):

- ConnectionManager owns a ProtocolListener and runs inbound handshakes concurrently (semaphore-bounded, establish deadline), so a stalling peer can neither block other servers nor hold a slot forever.
- Each established connection is arbitrated against the incumbent via the public should_switch() policy fn (playback wins; discovery never displaces playback; last-played breaks discovery ties). Losers and displaced incumbents automatically get client/goodbye(another_server), bounded by a goodbye_timeout so a peer that stops reading cannot pin the flush until the OS TCP timeout.
- Winners are yielded from next_connection() minus their guard; the manager keeps teardown authority. Channel closure means the connection is over. Last-played is a policy input (set_last_played) — the SDK does not persist state.
- ConnectionGuard gains a watch-channel death signal (closed()/ is_closed()); the router task drops the sender on any exit. Used to clear a dead incumbent and to avoid arbitrating live servers against (or flushing goodbyes at) dead ones.
- Handshake and goodbye tasks live in JoinSets so dropping the manager aborts them promptly, releasing sockets and the bound port.
- server_initiated_metadata example rewritten on top of the manager.

Non-goals, deliberately: last-played persistence (application domain) and a reconnect-backoff loop (the cpp reference has none either; its backoff is hello-send retry).