### PR TITLE
feat!: Add visualizer role support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add spec-aligned `visualizer@v1` negotiation and forwarding for loudness, beat,
+  dominant-frequency, spectrum, and peak data. Visualizer payloads remain raw
+  bytes for applications to decode and render.
+
+### Changed
+
+- Expand visualizer stream configuration and format-request APIs.
+
 ## [0.3.6](https://github.com/Sendspin/sendspin-rs/compare/v0.3.5...v0.3.6) - 2026-07-15
 
 ### Other

--- a/src/protocol/client.rs
+++ b/src/protocol/client.rs
@@ -7,7 +7,7 @@ use crate::protocol::messages::{
     ArtworkFormatRequest, ClientCommand, ClientGoodbye, ClientHello, ClientState, ClientSyncState,
     ClientTime, ControllerCommand, ControllerCommandType, GoodbyeReason, Message,
     PlayerFormatRequest, PlayerState, RepeatMode, ServerHello, StreamEnd, StreamRequestFormat,
-    StreamStart,
+    StreamStart, VisualizerDataType, VisualizerFormatRequest,
 };
 use crate::sync::raw_clock::Clock;
 use crate::sync::ClockSync;
@@ -118,14 +118,15 @@ pub struct Connection {
 /// the versioned `player@v1` names used during role negotiation.
 const ROLE_PLAYER: &str = "player";
 const ROLE_ARTWORK: &str = "artwork";
+const ROLE_VISUALIZER: &str = "visualizer";
 
 /// Which role streams are currently active, updated by the message router from
-/// `stream/start` and `stream/end`. Only `player` and `artwork` are tracked —
-/// the only roles `stream/request-format` can target.
+/// `stream/start` and `stream/end`.
 #[derive(Debug, Default)]
 struct StreamState {
     player_active: AtomicBool,
     artwork_active: AtomicBool,
+    visualizer_active: AtomicBool,
 }
 
 impl StreamState {
@@ -138,6 +139,9 @@ impl StreamState {
         if start.artwork.is_some() {
             self.artwork_active.store(true, Ordering::Release);
         }
+        if start.visualizer.is_some() {
+            self.visualizer_active.store(true, Ordering::Release);
+        }
     }
 
     /// `stream/end` with no roles ends every stream; otherwise only those listed.
@@ -148,6 +152,9 @@ impl StreamState {
         if role_ended(end, ROLE_ARTWORK) {
             self.artwork_active.store(false, Ordering::Release);
         }
+        if role_ended(end, ROLE_VISUALIZER) {
+            self.visualizer_active.store(false, Ordering::Release);
+        }
     }
 
     fn is_player_active(&self) -> bool {
@@ -156,6 +163,10 @@ impl StreamState {
 
     fn is_artwork_active(&self) -> bool {
         self.artwork_active.load(Ordering::Acquire)
+    }
+
+    fn is_visualizer_active(&self) -> bool {
+        self.visualizer_active.load(Ordering::Acquire)
     }
 }
 
@@ -245,9 +256,9 @@ impl WsSender {
     /// as `None` are unconstrained by the client.
     ///
     /// This low-level sender does not enforce negotiated roles; callers should
-    /// only use it for connections where the server granted `player@v1` and/or
-    /// `artwork@v1`. Use [`Connection::server_hello`] when you need to inspect
-    /// the negotiated roles before sending.
+    /// only use it for connections where the server granted the requested role.
+    /// Use [`Connection::server_hello`] when you need to inspect the negotiated
+    /// roles before sending.
     ///
     /// A requested component is rejected unless that role's stream is currently
     /// active (between its `stream/start` and `stream/end`): there is nothing to
@@ -257,10 +268,31 @@ impl WsSender {
         player: Option<PlayerFormatRequest>,
         artwork: Option<ArtworkFormatRequest>,
     ) -> Result<(), Error> {
-        if player.is_none() && artwork.is_none() {
+        self.request_stream_formats(player, artwork, None).await
+    }
+
+    /// Request changes to any combination of active stream formats.
+    ///
+    /// Each supplied component must have a corresponding active stream. The
+    /// existing [`Self::request_stream_format`] method remains available for
+    /// player/artwork-only callers.
+    pub async fn request_stream_formats(
+        &self,
+        player: Option<PlayerFormatRequest>,
+        artwork: Option<ArtworkFormatRequest>,
+        visualizer: Option<VisualizerFormatRequest>,
+    ) -> Result<(), Error> {
+        if player.is_none() && artwork.is_none() && visualizer.is_none() {
             return Err(Error::Protocol(
-                "stream/request-format requires player or artwork request".to_string(),
+                "stream/request-format requires a player, artwork, or visualizer request"
+                    .to_string(),
             ));
+        }
+
+        if let Some(request) = visualizer.as_ref() {
+            request
+                .validate()
+                .map_err(|message| Error::Protocol(message.to_string()))?;
         }
 
         if player.is_some() && !self.stream_state.is_player_active() {
@@ -275,9 +307,16 @@ impl WsSender {
             ));
         }
 
+        if visualizer.is_some() && !self.stream_state.is_visualizer_active() {
+            return Err(Error::Protocol(
+                "stream/request-format requires an active visualizer stream".to_string(),
+            ));
+        }
+
         self.send_message(Message::StreamRequestFormat(StreamRequestFormat {
             player,
             artwork,
+            visualizer,
         }))
         .await
     }
@@ -290,6 +329,15 @@ impl WsSender {
     /// Request a change to an active artwork stream format.
     pub async fn request_artwork_format(&self, artwork: ArtworkFormatRequest) -> Result<(), Error> {
         self.request_stream_format(None, Some(artwork)).await
+    }
+
+    /// Request a change to an active visualizer stream format.
+    pub async fn request_visualizer_format(
+        &self,
+        visualizer: VisualizerFormatRequest,
+    ) -> Result<(), Error> {
+        self.request_stream_formats(None, None, Some(visualizer))
+            .await
     }
 
     fn send_goodbye(
@@ -418,9 +466,16 @@ pub mod binary_types {
     pub const ARTWORK_CHANNEL_2: u8 = 0x0A;
     /// Artwork channel 3 (type 11)
     pub const ARTWORK_CHANNEL_3: u8 = 0x0B;
-    /// Visualizer data (type 16)
-    pub const VISUALIZER: u8 = 0x10;
-
+    /// Visualizer loudness data (type 16).
+    pub const VISUALIZER_LOUDNESS: u8 = 0x10;
+    /// Visualizer beat data (type 17).
+    pub const VISUALIZER_BEAT: u8 = 0x11;
+    /// Visualizer dominant-frequency data (type 18).
+    pub const VISUALIZER_F_PEAK: u8 = 0x12;
+    /// Visualizer spectrum data (type 19).
+    pub const VISUALIZER_SPECTRUM: u8 = 0x13;
+    /// Visualizer energy-onset data (type 20).
+    pub const VISUALIZER_PEAK: u8 = 0x14;
     /// Check if a binary type ID is for artwork (8-11)
     pub fn is_artwork(type_id: u8) -> bool {
         (ARTWORK_CHANNEL_0..=ARTWORK_CHANNEL_3).contains(&type_id)
@@ -433,6 +488,11 @@ pub mod binary_types {
         } else {
             None
         }
+    }
+
+    /// Check if a binary type ID is for visualizer data (16-20).
+    pub fn is_visualizer(type_id: u8) -> bool {
+        (VISUALIZER_LOUDNESS..=VISUALIZER_PEAK).contains(&type_id)
     }
 }
 
@@ -519,17 +579,34 @@ impl ArtworkChunk {
     }
 }
 
-/// Visualizer chunk from server (binary type 16)
+/// Visualizer chunk from server (binary types 16-20).
 #[derive(Debug, Clone)]
 pub struct VisualizerChunk {
-    /// Server timestamp in microseconds
+    /// Visualizer binary message type (16-20).
+    pub type_id: u8,
+    /// Server timestamp in microseconds.
     pub timestamp: i64,
-    /// FFT/visualization data bytes
+    /// Raw visualization data bytes, left for the application to decode.
     pub data: Arc<[u8]>,
 }
 
 impl VisualizerChunk {
-    /// Parse from WebSocket binary frame (type 16 = visualizer)
+    /// Return the typed visualizer data kind represented by this chunk.
+    ///
+    /// Returns `None` if a chunk was constructed manually with an invalid
+    /// `type_id`; frames parsed by [`Self::from_bytes`] always return `Some`.
+    pub fn data_type(&self) -> Option<VisualizerDataType> {
+        match self.type_id {
+            binary_types::VISUALIZER_LOUDNESS => Some(VisualizerDataType::Loudness),
+            binary_types::VISUALIZER_BEAT => Some(VisualizerDataType::Beat),
+            binary_types::VISUALIZER_F_PEAK => Some(VisualizerDataType::FPeak),
+            binary_types::VISUALIZER_SPECTRUM => Some(VisualizerDataType::Spectrum),
+            binary_types::VISUALIZER_PEAK => Some(VisualizerDataType::Peak),
+            _ => None,
+        }
+    }
+
+    /// Parse from a WebSocket binary frame (visualizer types 16-20).
     pub fn from_bytes(frame: &[u8]) -> Result<Self, Error> {
         if frame.len() < 9 {
             return Err(Error::Protocol(format!(
@@ -538,10 +615,9 @@ impl VisualizerChunk {
             )));
         }
 
-        if frame[0] != binary_types::VISUALIZER {
+        if !binary_types::is_visualizer(frame[0]) {
             return Err(Error::Protocol(format!(
-                "Invalid visualizer chunk type: expected {}, got {}",
-                binary_types::VISUALIZER,
+                "Invalid visualizer chunk type: expected 16-20, got {}",
                 frame[0]
             )));
         }
@@ -552,7 +628,11 @@ impl VisualizerChunk {
 
         let data = Arc::from(&frame[9..]);
 
-        Ok(Self { timestamp, data })
+        Ok(Self {
+            type_id: frame[0],
+            timestamp,
+            data,
+        })
     }
 }
 
@@ -563,7 +643,7 @@ pub enum BinaryFrame {
     Audio(AudioChunk),
     /// Artwork image (types 8-11)
     Artwork(ArtworkChunk),
-    /// Visualizer data (type 16)
+    /// Visualizer data (types 16-20)
     Visualizer(VisualizerChunk),
     /// Unknown binary type
     Unknown {
@@ -588,7 +668,7 @@ impl BinaryFrame {
             t if binary_types::is_artwork(t) => {
                 Ok(BinaryFrame::Artwork(ArtworkChunk::from_bytes(frame)?))
             }
-            binary_types::VISUALIZER => {
+            t if binary_types::is_visualizer(t) => {
                 Ok(BinaryFrame::Visualizer(VisualizerChunk::from_bytes(frame)?))
             }
             // The router warns when it sees the Unknown variant; parsing

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -188,11 +188,78 @@ pub enum ImageFormat {
     Bmp,
 }
 
-/// Visualizer@v1 capabilities
+/// Visualizer@v1 capabilities.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VisualizerV1Support {
-    /// Buffer capacity for visualization data
+    /// Visualization data types requested by the client.
+    pub types: Vec<VisualizerDataType>,
+    /// Maximum total size of buffered visualizer messages in bytes.
     pub buffer_capacity: u32,
+    /// Maximum periodic visualization frames per second.
+    pub rate_max: u32,
+    /// Spectrum configuration, required when `types` includes `spectrum`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub spectrum: Option<SpectrumConfig>,
+}
+
+impl VisualizerV1Support {
+    /// Validate the cross-field spectrum requirement from the Sendspin spec.
+    pub fn validate(&self) -> Result<(), &'static str> {
+        validate_spectrum(&self.types, self.spectrum.as_ref())
+    }
+}
+
+/// Visualization data type carried by a visualizer binary message.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum VisualizerDataType {
+    /// Overall A-weighted loudness.
+    Loudness,
+    /// Musical beat event.
+    Beat,
+    /// Dominant frequency and amplitude.
+    FPeak,
+    /// FFT magnitudes mapped to display bins.
+    Spectrum,
+    /// Energy onset event.
+    Peak,
+}
+
+/// Spectrum display-bin configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SpectrumConfig {
+    /// Number of display bins.
+    pub n_disp_bins: u32,
+    /// Frequency-to-bin mapping.
+    pub scale: SpectrumScale,
+    /// Lowest frequency in Hz.
+    pub f_min: u32,
+    /// Highest frequency in Hz.
+    pub f_max: u32,
+}
+
+fn validate_spectrum(
+    types: &[VisualizerDataType],
+    spectrum: Option<&SpectrumConfig>,
+) -> Result<(), &'static str> {
+    let has_spectrum = types.contains(&VisualizerDataType::Spectrum);
+    match (has_spectrum, spectrum.is_some()) {
+        (true, false) => Err("spectrum configuration is required for spectrum data"),
+        (false, true) => Err("spectrum configuration requires spectrum data"),
+        _ => Ok(()),
+    }
+}
+
+/// Frequency-to-bin mapping for spectrum data.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SpectrumScale {
+    /// HTK mel-frequency spacing.
+    Mel,
+    /// Base-10 logarithmic spacing.
+    Log,
+    /// Linear frequency spacing.
+    Lin,
 }
 
 /// Server hello message
@@ -549,10 +616,26 @@ pub struct StreamArtworkChannelConfig {
     pub height: u32,
 }
 
-/// Stream visualizer configuration
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Stream visualizer configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct StreamVisualizerConfig {
-    // FFT details TBD per spec
+    /// Visualization data types the server will stream.
+    pub types: Vec<VisualizerDataType>,
+    /// Maximum periodic visualization frames per second.
+    pub rate_max: u32,
+    /// Whether the beat tracker identifies bar starts.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tracks_downbeats: Option<bool>,
+    /// Spectrum configuration, present when `types` includes `spectrum`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub spectrum: Option<SpectrumConfig>,
+}
+
+impl StreamVisualizerConfig {
+    /// Validate the cross-field spectrum requirement from the Sendspin spec.
+    pub fn validate(&self) -> Result<(), &'static str> {
+        validate_spectrum(&self.types, self.spectrum.as_ref())
+    }
 }
 
 /// Stream end message
@@ -580,6 +663,40 @@ pub struct StreamRequestFormat {
     /// Requested artwork format
     #[serde(skip_serializing_if = "Option::is_none")]
     pub artwork: Option<ArtworkFormatRequest>,
+    /// Requested visualizer format
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub visualizer: Option<VisualizerFormatRequest>,
+}
+
+/// Requested visualizer stream format. Omitted fields keep their current value.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct VisualizerFormatRequest {
+    /// New visualization data types.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub types: Option<Vec<VisualizerDataType>>,
+    /// New periodic visualization frames-per-second cap.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rate_max: Option<u32>,
+    /// New spectrum configuration.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub spectrum: Option<SpectrumConfig>,
+}
+
+impl VisualizerFormatRequest {
+    /// Validate that this request changes at least one field.
+    ///
+    /// This is a partial update: omitted fields retain their current value, so
+    /// a request may omit `spectrum` even when its new `types` includes it.
+    pub fn validate(&self) -> Result<(), &'static str> {
+        if self.types.is_none() && self.rate_max.is_none() && self.spectrum.is_none() {
+            return Err("visualizer format request must specify at least one field");
+        }
+        if let (Some(types), Some(spectrum)) = (self.types.as_ref(), self.spectrum.as_ref()) {
+            validate_spectrum(types, Some(spectrum))
+        } else {
+            Ok(())
+        }
+    }
 }
 
 /// Player format request

--- a/tests/binary_frames.rs
+++ b/tests/binary_frames.rs
@@ -16,7 +16,11 @@ fn test_binary_type_constants() {
     assert_eq!(binary_types::ARTWORK_CHANNEL_1, 0x09);
     assert_eq!(binary_types::ARTWORK_CHANNEL_2, 0x0A);
     assert_eq!(binary_types::ARTWORK_CHANNEL_3, 0x0B);
-    assert_eq!(binary_types::VISUALIZER, 0x10);
+    assert_eq!(binary_types::VISUALIZER_LOUDNESS, 0x10);
+    assert_eq!(binary_types::VISUALIZER_BEAT, 0x11);
+    assert_eq!(binary_types::VISUALIZER_F_PEAK, 0x12);
+    assert_eq!(binary_types::VISUALIZER_SPECTRUM, 0x13);
+    assert_eq!(binary_types::VISUALIZER_PEAK, 0x14);
 }
 
 #[test]
@@ -29,6 +33,15 @@ fn test_is_artwork() {
     assert!(binary_types::is_artwork(0x0B)); // Artwork channel 3
     assert!(!binary_types::is_artwork(0x0C)); // Out of range
     assert!(!binary_types::is_artwork(0x10)); // Visualizer
+}
+
+#[test]
+fn test_is_visualizer() {
+    for type_id in 0x10..=0x14 {
+        assert!(binary_types::is_visualizer(type_id));
+    }
+    assert!(!binary_types::is_visualizer(0x0F));
+    assert!(!binary_types::is_visualizer(0x15));
 }
 
 #[test]
@@ -176,14 +189,43 @@ fn test_artwork_chunk_wrong_type() {
 #[test]
 fn test_visualizer_chunk_parsing() {
     let frame: Vec<u8> = vec![
-        0x10, // Type: visualizer
+        0x10, // Loudness
         0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x86, 0xA0, // Timestamp: 100000
-        0x01, 0x02, 0x03, 0x04, 0x05, // FFT data
+        0x01, 0x02, 0x03, 0x04, 0x05, // Raw visualization data
     ];
 
     let chunk = VisualizerChunk::from_bytes(&frame).unwrap();
+    assert_eq!(chunk.type_id, 0x10);
+    assert_eq!(
+        chunk.data_type(),
+        Some(sendspin::protocol::messages::VisualizerDataType::Loudness)
+    );
     assert_eq!(chunk.timestamp, 100000);
-    assert_eq!(chunk.data.len(), 5);
+    assert_eq!(&*chunk.data, &[0x01, 0x02, 0x03, 0x04, 0x05]);
+}
+
+#[test]
+fn test_all_visualizer_types_are_accepted() {
+    let expected = [
+        sendspin::protocol::messages::VisualizerDataType::Loudness,
+        sendspin::protocol::messages::VisualizerDataType::Beat,
+        sendspin::protocol::messages::VisualizerDataType::FPeak,
+        sendspin::protocol::messages::VisualizerDataType::Spectrum,
+        sendspin::protocol::messages::VisualizerDataType::Peak,
+    ];
+    for (type_id, expected_type) in (0x10..=0x14).zip(expected) {
+        let frame = [type_id, 0, 0, 0, 0, 0, 0, 0, 1, 0xAA];
+        let chunk = VisualizerChunk::from_bytes(&frame).unwrap();
+        assert_eq!(chunk.type_id, type_id);
+        assert_eq!(chunk.data_type(), Some(expected_type));
+        assert_eq!(&*chunk.data, &[0xAA]);
+    }
+}
+
+#[test]
+fn test_reserved_visualizer_type_is_rejected() {
+    let frame = [0x15, 0, 0, 0, 0, 0, 0, 0, 1, 0xAA];
+    assert!(VisualizerChunk::from_bytes(&frame).is_err());
 }
 
 #[test]
@@ -260,12 +302,13 @@ fn test_binary_frame_artwork() {
 #[test]
 fn test_binary_frame_visualizer() {
     let frame: Vec<u8> = vec![
-        0x10, // Visualizer
+        0x13, // Spectrum
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x56, 0x78,
     ];
 
     match BinaryFrame::from_bytes(&frame).unwrap() {
         BinaryFrame::Visualizer(chunk) => {
+            assert_eq!(chunk.type_id, 0x13);
             assert_eq!(chunk.timestamp, 3);
         }
         _ => panic!("Expected Visualizer frame"),

--- a/tests/protocol_client.rs
+++ b/tests/protocol_client.rs
@@ -5,6 +5,7 @@ use sendspin::protocol::messages::{
     ConnectionReason, ControllerCommandType, GoodbyeReason, ImageFormat, Message,
     PlayerFormatRequest, PlayerState, PlayerV1Support, RepeatMode, StreamArtworkChannelConfig,
     StreamArtworkConfig, StreamEnd, StreamPlayerConfig, StreamRequestFormat, StreamStart,
+    VisualizerDataType, VisualizerFormatRequest,
 };
 use sendspin::ProtocolClientBuilder;
 use tokio::net::TcpListener;
@@ -101,6 +102,20 @@ fn artwork_stream_start() -> WsMessage {
             }],
         }),
         visualizer: None,
+    }))
+}
+
+/// A server→client `stream/start` that starts a visualizer stream.
+fn visualizer_stream_start() -> WsMessage {
+    text_message(&Message::StreamStart(StreamStart {
+        player: None,
+        artwork: None,
+        visualizer: Some(sendspin::protocol::messages::StreamVisualizerConfig {
+            types: vec![VisualizerDataType::Spectrum],
+            rate_max: 60,
+            tracks_downbeats: None,
+            spectrum: None,
+        }),
     }))
 }
 
@@ -427,7 +442,7 @@ async fn test_sender_rejects_empty_stream_request_format() {
 
     match result {
         Err(Error::Protocol(msg)) => assert!(
-            msg.contains("requires player or artwork request"),
+            msg.contains("requires a player, artwork, or visualizer request"),
             "unexpected protocol error: {msg}"
         ),
         other => panic!("expected protocol error, got {:?}", other),
@@ -467,6 +482,58 @@ async fn test_sender_rejects_request_format_before_stream_start() {
         ),
         other => panic!("expected protocol error, got {:?}", other),
     }
+}
+
+#[tokio::test]
+async fn test_sender_visualizer_request_requires_active_stream() {
+    let (url, mut rx, server_tx, _handle) = start_test_server_with_sender().await;
+
+    let client = ProtocolClientBuilder::builder()
+        .client_id("test-client".to_string())
+        .name("Test".to_string())
+        .visualizer_v1_support(sendspin::protocol::messages::VisualizerV1Support {
+            types: vec![VisualizerDataType::Spectrum],
+            buffer_capacity: 4096,
+            rate_max: 60,
+            spectrum: None,
+        })
+        .build()
+        .connect(&url)
+        .await
+        .unwrap();
+    let mut conn = client.split();
+    discard_initial_state(&mut rx).await;
+
+    let request = VisualizerFormatRequest {
+        types: Some(vec![VisualizerDataType::Loudness]),
+        rate_max: Some(30),
+        spectrum: None,
+    };
+    let empty = VisualizerFormatRequest {
+        types: None,
+        rate_max: None,
+        spectrum: None,
+    };
+    let result = conn.sender.request_visualizer_format(empty).await;
+    assert!(matches!(result, Err(Error::Protocol(msg)) if msg.contains("at least one field")));
+
+    let result = conn.sender.request_visualizer_format(request.clone()).await;
+    assert!(
+        matches!(result, Err(Error::Protocol(msg)) if msg.contains("active visualizer stream"))
+    );
+
+    server_tx.send(visualizer_stream_start()).unwrap();
+    await_message(&mut conn.messages, |m| matches!(m, Message::StreamStart(_))).await;
+
+    conn.sender
+        .request_visualizer_format(request)
+        .await
+        .unwrap();
+    let sent = recv_stream_request_format(&mut rx).await;
+    assert_eq!(
+        sent.visualizer.expect("visualizer request").rate_max,
+        Some(30)
+    );
 }
 
 #[tokio::test]
@@ -1169,8 +1236,25 @@ async fn test_message_router_forwards_binary_visualizer() {
         .await
         .expect("timed out waiting for visualizer chunk")
         .expect("visualizer channel closed");
+    assert_eq!(chunk.type_id, 0x10);
     assert_eq!(chunk.timestamp, 200);
     assert_eq!(&*chunk.data, &[0x01, 0x02, 0x03]);
+
+    for (type_id, expected) in [(0x11, vec![0x01]), (0x13, vec![0x02, 0x03])] {
+        server_tx
+            .send(WsMessage::Binary(
+                [vec![type_id], vec![0; 8], expected.clone()]
+                    .concat()
+                    .into(),
+            ))
+            .unwrap();
+        let chunk = tokio::time::timeout(std::time::Duration::from_secs(2), conn.visualizer.recv())
+            .await
+            .expect("timed out waiting for visualizer chunk")
+            .expect("visualizer channel closed");
+        assert_eq!(chunk.type_id, type_id);
+        assert_eq!(&*chunk.data, expected.as_slice());
+    }
 }
 
 #[tokio::test]

--- a/tests/protocol_client_builder.rs
+++ b/tests/protocol_client_builder.rs
@@ -1,7 +1,7 @@
 use sendspin::protocol::client_builder::ProtocolClientBuilder;
 use sendspin::protocol::messages::{
     ArtworkChannel, ArtworkSource, ArtworkV1Support, AudioFormatSpec, ImageFormat, PlayerV1Support,
-    VisualizerV1Support,
+    VisualizerDataType, VisualizerV1Support,
 };
 
 #[test]
@@ -80,7 +80,10 @@ fn test_supported_roles_with_visualizer_v1_support() {
         .client_id("test".to_string())
         .name("Test Client".to_string())
         .visualizer_v1_support(VisualizerV1Support {
+            types: vec![VisualizerDataType::Spectrum],
             buffer_capacity: 1024,
+            rate_max: 60,
+            spectrum: None,
         })
         .build();
 
@@ -111,7 +114,10 @@ fn test_supported_roles_with_multiple_supports() {
             }],
         })
         .visualizer_v1_support(VisualizerV1Support {
+            types: vec![VisualizerDataType::Loudness],
             buffer_capacity: 1024,
+            rate_max: 60,
+            spectrum: None,
         })
         .controller()
         .build();

--- a/tests/protocol_messages.rs
+++ b/tests/protocol_messages.rs
@@ -3,8 +3,9 @@ use sendspin::protocol::messages::{
     ClientCommand, ClientGoodbye, ClientHello, ClientState, ClientSyncState, ClientTime,
     ConnectionReason, ControllerCommand, ControllerCommandType, DeviceInfo, GoodbyeReason,
     ImageFormat, Message, PlaybackState, PlayerCommandType, PlayerFormatRequest, PlayerState,
-    PlayerStateCommand, PlayerV1Support, RepeatMode, ServerTime, StreamArtworkChannelConfig,
-    StreamRequestFormat,
+    PlayerStateCommand, PlayerV1Support, RepeatMode, ServerTime, SpectrumConfig, SpectrumScale,
+    StreamArtworkChannelConfig, StreamRequestFormat, StreamVisualizerConfig, VisualizerDataType,
+    VisualizerFormatRequest, VisualizerV1Support,
 };
 
 // =============================================================================
@@ -318,6 +319,88 @@ fn test_stream_start_deserialization() {
 }
 
 #[test]
+fn test_visualizer_negotiation_serialization() {
+    let hello = ClientHello {
+        client_id: "visualizer-client".to_string(),
+        name: "Visualizer".to_string(),
+        version: 1,
+        supported_roles: vec!["visualizer@v1".to_string()],
+        device_info: None,
+        player_v1_support: None,
+        artwork_v1_support: None,
+        visualizer_v1_support: Some(VisualizerV1Support {
+            types: vec![VisualizerDataType::Loudness, VisualizerDataType::Spectrum],
+            buffer_capacity: 4096,
+            rate_max: 60,
+            spectrum: Some(SpectrumConfig {
+                n_disp_bins: 32,
+                scale: SpectrumScale::Mel,
+                f_min: 40,
+                f_max: 16_000,
+            }),
+        }),
+    };
+    let json = serde_json::to_string(&Message::ClientHello(hello)).unwrap();
+    assert!(json.contains("\"visualizer@v1_support\""));
+    assert!(json.contains("\"types\":[\"loudness\",\"spectrum\"]"));
+    assert!(json.contains("\"scale\":\"mel\""));
+
+    let start: Message = serde_json::from_str(
+        r#"{
+            "type": "stream/start",
+            "payload": {
+                "visualizer": {
+                    "types": ["beat", "peak"],
+                    "rate_max": 30,
+                    "tracks_downbeats": true
+                }
+            }
+        }"#,
+    )
+    .unwrap();
+    match start {
+        Message::StreamStart(start) => {
+            assert_eq!(
+                start.visualizer,
+                Some(StreamVisualizerConfig {
+                    types: vec![VisualizerDataType::Beat, VisualizerDataType::Peak],
+                    rate_max: 30,
+                    tracks_downbeats: Some(true),
+                    spectrum: None,
+                })
+            );
+        }
+        other => panic!("expected stream/start, got {other:?}"),
+    }
+
+    let request = StreamRequestFormat {
+        player: None,
+        artwork: None,
+        visualizer: Some(VisualizerFormatRequest {
+            types: Some(vec![VisualizerDataType::FPeak]),
+            rate_max: Some(24),
+            spectrum: None,
+        }),
+    };
+    let json = serde_json::to_string(&Message::StreamRequestFormat(request)).unwrap();
+    assert!(json.contains("\"visualizer\""));
+    assert!(json.contains("\"f_peak\""));
+
+    let partial = VisualizerFormatRequest {
+        types: Some(vec![VisualizerDataType::Spectrum]),
+        rate_max: None,
+        spectrum: None,
+    };
+    assert!(partial.validate().is_ok());
+    let empty = VisualizerFormatRequest {
+        types: None,
+        rate_max: None,
+        spectrum: None,
+    };
+    assert!(empty.validate().is_err());
+}
+
+#[test]
 fn test_stream_end_deserialization() {
     let json = r#"{
         "type": "stream/end",
@@ -369,6 +452,7 @@ fn test_stream_request_format_serialization() {
             media_width: Some(600),
             media_height: Some(600),
         }),
+        visualizer: None,
     };
 
     let message = Message::StreamRequestFormat(request);
@@ -393,6 +477,7 @@ fn test_stream_request_format_omits_unspecified_fields() {
             bit_depth: None,
         }),
         artwork: None,
+        visualizer: None,
     };
 
     let json = serde_json::to_string(&Message::StreamRequestFormat(request)).unwrap();


### PR DESCRIPTION
Updating to the newer 4-way split for the visualizer role. This is an ABI-breaking change, but I won't release 0.4.0 just yet as the spec is changing rapidly and there are already a few other breaking changes we'll need to make to become spec-compatible again. Figure we can bundle a few up to minimize the pain.

Implement spec-aligned visualizer negotiation for loudness, beat, peak, f_peak, and spectrum data. Forward raw timestamped visualizer payloads to applications, add stream format requests and validation, and cover the new protocol paths with tests.