### PR TITLE
feat: add Opus audio decoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,9 @@ uuid = { version = "1.23", features = ["v4", "serde"] }
 # Audio output
 cpal = "0.18"
 
-# Audio decoding
+# Audio codecs
 flac-codec = "=1.3.2"
+opus-rs = "=0.1.23"
 
 # Concurrency
 crossbeam = "0.8"

--- a/examples/player.rs
+++ b/examples/player.rs
@@ -2,8 +2,8 @@
 // ABOUTME: Connects to server, receives audio, and plays it back
 
 use base64::prelude::*;
-use clap::Parser;
-use sendspin::audio::decode::{Decoder, FlacDecoder, PcmDecoder, PcmEndian};
+use clap::{Parser, ValueEnum};
+use sendspin::audio::decode::{Decoder, FlacDecoder, OpusDecoder, PcmDecoder, PcmEndian};
 use sendspin::audio::{AudioBuffer, AudioFormat, Codec, SyncedPlayer, SyncedPlayerConfig};
 use sendspin::protocol::messages::{
     AudioFormatSpec, Message, PlayerCommand, PlayerCommandType, PlayerFormatRequest, PlayerState,
@@ -108,6 +108,13 @@ fn env_bool(key: &str) -> bool {
         .unwrap_or(false)
 }
 
+#[derive(Copy, Clone, Debug, ValueEnum)]
+enum CodecChoice {
+    Pcm,
+    Opus,
+    Flac,
+}
+
 /// Sendspin audio player
 #[derive(Parser, Debug)]
 #[command(name = "player")]
@@ -124,6 +131,10 @@ struct Args {
     /// Player ID (optional, generates random UUID if not provided)
     #[arg(short = 'i', long = "id")]
     id: Option<String>,
+
+    /// Restrict negotiation to one codec (pcm, opus, or flac)
+    #[arg(long, value_enum)]
+    codec: Option<CodecChoice>,
 
     /// List all available audio output devices and exit
     #[arg(long = "list-audio-devices")]
@@ -169,11 +180,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let required_lead_time_ms = 500;
     let min_buffer_ms = 500;
 
-    // Advertise FLAC ahead of PCM so servers that support it send the
-    // bandwidth-friendly lossless stream; PCM remains the fallback.
-    let supported_formats = [("flac", 24), ("flac", 16), ("pcm", 24), ("pcm", 16)]
-        .into_iter()
-        .map(|(codec, bit_depth)| AudioFormatSpec {
+    // Advertise all supported codecs by default, preferring FLAC, then Opus,
+    // then PCM. The --codec flag restricts negotiation when a specific decoder
+    // needs exercising.
+    let formats: &[(&str, u8)] = match args.codec {
+        Some(CodecChoice::Pcm) => &[("pcm", 24), ("pcm", 16)],
+        Some(CodecChoice::Opus) => &[("opus", 16)],
+        Some(CodecChoice::Flac) => &[("flac", 24), ("flac", 16)],
+        None => &[
+            ("flac", 24),
+            ("flac", 16),
+            ("opus", 16),
+            ("pcm", 24),
+            ("pcm", 16),
+        ],
+    };
+    let supported_formats = formats
+        .iter()
+        .map(|&(codec, bit_depth)| AudioFormatSpec {
             codec: codec.to_string(),
             channels: 2,
             sample_rate: 48000,
@@ -280,9 +304,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             // Validate codec before proceeding
                             let codec = match player_config.codec.as_str() {
                                 "pcm" => Codec::Pcm,
+                                "opus" => Codec::Opus,
                                 "flac" => Codec::Flac,
                                 other => {
-                                    eprintln!("ERROR: Unsupported codec '{}' - only 'pcm' and 'flac' are supported!", other);
+                                    eprintln!("ERROR: Unsupported codec '{}' - only 'pcm', 'opus', and 'flac' are supported!", other);
                                     eprintln!("Server is sending compressed audio that we can't decode!");
                                     continue;
                                 }
@@ -310,6 +335,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 // PCM decoder is created on the first chunk,
                                 // after endianness is locked in.
                                 Codec::Pcm => None,
+                                Codec::Opus => match OpusDecoder::new(
+                                    player_config.sample_rate,
+                                    player_config.channels,
+                                ) {
+                                    Ok(opus) => Some(Box::new(opus)),
+                                    Err(e) => {
+                                        eprintln!("ERROR: Invalid Opus stream format: {}", e);
+                                        continue;
+                                    }
+                                },
                                 Codec::Flac => {
                                     let flac = match codec_header.as_deref() {
                                         Some(header) => match FlacDecoder::with_header(header) {
@@ -323,8 +358,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     };
                                     Some(Box::new(flac))
                                 }
-                                // `codec` was narrowed to Pcm/Flac when parsing
-                                // player_config.codec above.
+                                // `codec` was narrowed to Pcm/Opus/Flac when
+                                // parsing player_config.codec above.
                                 _ => unreachable!(),
                             };
 

--- a/src/audio/decode/mod.rs
+++ b/src/audio/decode/mod.rs
@@ -1,12 +1,15 @@
 // ABOUTME: Audio decoder implementations
-// ABOUTME: PCM and FLAC decoders (Opus planned)
+// ABOUTME: PCM, Opus, and FLAC decoders
 
 /// FLAC decoder implementation
 pub mod flac;
+/// Opus decoder implementation
+pub mod opus;
 /// PCM decoder implementation
 pub mod pcm;
 
 pub use flac::FlacDecoder;
+pub use opus::OpusDecoder;
 pub use pcm::{PcmDecoder, PcmEndian};
 
 use crate::error::Error;

--- a/src/audio/decode/opus.rs
+++ b/src/audio/decode/opus.rs
@@ -1,0 +1,133 @@
+// ABOUTME: Opus decoder implementation
+// ABOUTME: Stateful pure-Rust packet decoding through opus-rs
+
+use crate::audio::decode::Decoder;
+use crate::error::Error;
+use parking_lot::Mutex;
+use std::sync::Arc;
+
+/// Stateful Opus decoder for raw Sendspin Opus packets.
+///
+/// Sendspin carries one complete Opus packet per binary audio chunk. The
+/// decoder is kept behind a mutex because the public [`Decoder`] trait is
+/// shared by the player's message and audio handling paths while Opus itself
+/// requires mutable state between packets.
+pub struct OpusDecoder {
+    decoder: Mutex<opus_rs::OpusDecoder>,
+    channels: usize,
+    sample_rate: u32,
+}
+
+impl OpusDecoder {
+    /// Create an Opus decoder for the stream's sample rate and channel count.
+    pub fn new(sample_rate: u32, channels: u8) -> Result<Self, Error> {
+        let channels = usize::from(channels);
+        if !matches!(sample_rate, 8_000 | 12_000 | 16_000 | 24_000 | 48_000) {
+            return Err(Error::Protocol(format!(
+                "Unsupported Opus sample rate: {sample_rate}"
+            )));
+        }
+        if !matches!(channels, 1 | 2) {
+            return Err(Error::Protocol(format!(
+                "Unsupported Opus channel count: {channels}"
+            )));
+        }
+
+        let decoder = opus_rs::OpusDecoder::new(sample_rate as i32, channels).map_err(|error| {
+            Error::Protocol(format!("Opus decoder initialization failed: {error}"))
+        })?;
+
+        Ok(Self {
+            decoder: Mutex::new(decoder),
+            channels,
+            sample_rate,
+        })
+    }
+
+    fn frame_size_from_toc(&self, toc: u8) -> Result<usize, Error> {
+        let config = usize::from(toc >> 3);
+        let frame_size = match config {
+            0..=11 => [
+                self.sample_rate / 100,
+                self.sample_rate / 50,
+                self.sample_rate / 25,
+                self.sample_rate * 3 / 50,
+            ][config & 3],
+            12..=15 => [self.sample_rate / 100, self.sample_rate / 50][config & 1],
+            16..=31 => [
+                self.sample_rate / 400,
+                self.sample_rate / 200,
+                self.sample_rate / 100,
+                self.sample_rate / 50,
+            ][config & 3],
+            _ => unreachable!(),
+        };
+        if frame_size == 0 {
+            Err(Error::Protocol("Invalid Opus frame size".to_string()))
+        } else {
+            Ok(frame_size as usize)
+        }
+    }
+}
+
+impl Decoder for OpusDecoder {
+    fn decode(&self, data: &[u8]) -> Result<Arc<[i32]>, Error> {
+        if data.is_empty() {
+            return Err(Error::Protocol("Empty Opus packet".to_string()));
+        }
+
+        let frame_size = self.frame_size_from_toc(data[0])?;
+        let frame_count = match data[0] & 0x03 {
+            0 => 1,
+            1 | 2 => 2,
+            3 => usize::from(
+                data.get(1).ok_or_else(|| {
+                    Error::Protocol("Opus code-3 packet is missing its frame count".to_string())
+                })? & 0x3f,
+            ),
+            _ => unreachable!(),
+        };
+        if frame_count == 0 || frame_count > 48 {
+            return Err(Error::Protocol(format!(
+                "Invalid Opus frame count: {frame_count}"
+            )));
+        }
+        let mut output = vec![0.0f32; frame_size * self.channels * frame_count];
+        let mut decoder = self.decoder.lock();
+        let samples_per_channel = decoder
+            .decode(data, frame_size * frame_count, &mut output)
+            .map_err(|error| Error::Protocol(format!("Opus decode error: {error}")))?;
+        output.truncate(samples_per_channel * self.channels);
+
+        let samples = output
+            .into_iter()
+            .map(|sample| (sample.clamp(-1.0, 1.0) * i32::MAX as f32).round() as i32)
+            .collect::<Vec<_>>();
+        Ok(Arc::from(samples.into_boxed_slice()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_opus_rs_packet() {
+        let mut encoder =
+            opus_rs::OpusEncoder::new(48_000, 2, opus_rs::Application::Audio).unwrap();
+        encoder.bitrate_bps = 96_000;
+        let input = vec![0.0f32; 960 * 2];
+        let mut packet = vec![0u8; 1275];
+        let length = encoder.encode(&input, 960, &mut packet).unwrap();
+
+        let decoder = OpusDecoder::new(48_000, 2).unwrap();
+        let decoded = decoder.decode(&packet[..length]).unwrap();
+        assert_eq!(decoded.len(), 960 * 2);
+    }
+
+    #[test]
+    fn rejects_invalid_stream_parameters() {
+        assert!(OpusDecoder::new(44_100, 2).is_err());
+        assert!(OpusDecoder::new(48_000, 6).is_err());
+    }
+}

--- a/src/protocol/client_builder.rs
+++ b/src/protocol/client_builder.rs
@@ -50,6 +50,12 @@ impl From<ProtocolClientBuilderRaw> for ProtocolClientBuilder {
             Some(PlayerV1Support {
                 supported_formats: vec![
                     AudioFormatSpec {
+                        codec: "opus".to_string(),
+                        channels: 2,
+                        sample_rate: 48000,
+                        bit_depth: 16,
+                    },
+                    AudioFormatSpec {
                         codec: "pcm".to_string(),
                         channels: 2,
                         sample_rate: 48000,

--- a/tests/protocol_client_builder.rs
+++ b/tests/protocol_client_builder.rs
@@ -143,15 +143,19 @@ fn test_default_player_v1_support_applied_at_build_time() {
     let support = builder
         .player_v1_support()
         .expect("should have default player support");
-    assert_eq!(support.supported_formats.len(), 2);
-    assert_eq!(support.supported_formats[0].codec, "pcm");
+    assert_eq!(support.supported_formats.len(), 3);
+    assert_eq!(support.supported_formats[0].codec, "opus");
     assert_eq!(support.supported_formats[0].channels, 2);
     assert_eq!(support.supported_formats[0].sample_rate, 48000);
-    assert_eq!(support.supported_formats[0].bit_depth, 24);
+    assert_eq!(support.supported_formats[0].bit_depth, 16);
     assert_eq!(support.supported_formats[1].codec, "pcm");
     assert_eq!(support.supported_formats[1].channels, 2);
     assert_eq!(support.supported_formats[1].sample_rate, 48000);
-    assert_eq!(support.supported_formats[1].bit_depth, 16);
+    assert_eq!(support.supported_formats[1].bit_depth, 24);
+    assert_eq!(support.supported_formats[2].codec, "pcm");
+    assert_eq!(support.supported_formats[2].channels, 2);
+    assert_eq!(support.supported_formats[2].sample_rate, 48000);
+    assert_eq!(support.supported_formats[2].bit_depth, 16);
     assert_eq!(support.buffer_capacity, 50 * 1024 * 1024); // 50 MB
     assert_eq!(
         support.supported_commands,


### PR DESCRIPTION
There aren't a *ton* of rust opus libraries out there. opus-rs is the one that best matched our requirements in terms of license, encoding support (for when the server support PR lands), remaining pure rust vs. bringing in a bunch of `Unsafe` C code, and working with our existing audio pipeline. Tested locally, seems to produce clean audio.