### PR TITLE
Add controller seek and seek_relative command support

### DIFF
--- a/src/protocol/client.rs
+++ b/src/protocol/client.rs
@@ -377,6 +377,8 @@ impl Controller {
             command,
             volume: None,
             mute: None,
+            position_ms: None,
+            offset_ms: None,
         })
         .await
     }
@@ -413,6 +415,8 @@ impl Controller {
             command: ControllerCommandType::Volume,
             volume: Some(volume.clamp(0, 100)),
             mute: None,
+            position_ms: None,
+            offset_ms: None,
         })
         .await
     }
@@ -423,6 +427,8 @@ impl Controller {
             command: ControllerCommandType::Mute,
             volume: None,
             mute: Some(muted),
+            position_ms: None,
+            offset_ms: None,
         })
         .await
     }
@@ -451,6 +457,40 @@ impl Controller {
     pub async fn switch(&self) -> Result<(), Error> {
         self.send_simple_command(ControllerCommandType::Switch)
             .await
+    }
+
+    /// Seek to an absolute playback position in milliseconds.
+    ///
+    /// Only send this when `seek` is in the server's `supported_commands`.
+    /// Per the spec, the server ignores the command if `position_ms` is
+    /// outside the range 0 to
+    /// [`ControllerState::seek_max_ms`](crate::protocol::messages::ControllerState::seek_max_ms).
+    pub async fn seek(&self, position_ms: u64) -> Result<(), Error> {
+        self.send_controller_command(ControllerCommand {
+            command: ControllerCommandType::Seek,
+            volume: None,
+            mute: None,
+            position_ms: Some(position_ms),
+            offset_ms: None,
+        })
+        .await
+    }
+
+    /// Seek by a signed offset in milliseconds from the current position
+    /// (positive forward, negative backward).
+    ///
+    /// Only send this when `seek_relative` is in the server's
+    /// `supported_commands`. The server applies the offset on a best-effort
+    /// basis and clamps the result to the seekable range.
+    pub async fn seek_relative(&self, offset_ms: i64) -> Result<(), Error> {
+        self.send_controller_command(ControllerCommand {
+            command: ControllerCommandType::SeekRelative,
+            volume: None,
+            mute: None,
+            position_ms: None,
+            offset_ms: Some(offset_ms),
+        })
+        .await
     }
 }
 

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -464,6 +464,11 @@ pub struct ControllerState {
     /// Shuffle state
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shuffle: Option<bool>,
+    /// Maximum absolute position in milliseconds a 'seek' may target (e.g.,
+    /// the end of the current track). Present whenever 'seek' is in
+    /// `supported_commands`; absent when the seekable range is unknown.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub seek_max_ms: Option<u64>,
 }
 
 // =============================================================================
@@ -528,6 +533,14 @@ pub struct ControllerCommand {
     /// Optional mute state for mute command
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mute: Option<bool>,
+    /// Absolute playback position in milliseconds, range 0 to
+    /// [`ControllerState::seek_max_ms`]. Only set for the `seek` command.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub position_ms: Option<u64>,
+    /// Signed offset in milliseconds from the current position (positive
+    /// forward, negative backward). Only set for the `seek_relative` command.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset_ms: Option<i64>,
 }
 
 /// Controller command type
@@ -560,6 +573,10 @@ pub enum ControllerCommandType {
     Unshuffle,
     /// Switch to next group
     Switch,
+    /// Seek to an absolute position (requires `position_ms`)
+    Seek,
+    /// Seek by a signed offset from the current position (requires `offset_ms`)
+    SeekRelative,
 }
 
 // =============================================================================

--- a/tests/protocol_client.rs
+++ b/tests/protocol_client.rs
@@ -948,6 +948,30 @@ async fn test_controller_unshuffle_sends_correct_command() {
     assert_eq!(ctrl.command, ControllerCommandType::Unshuffle);
 }
 
+#[tokio::test]
+async fn test_controller_seek_sends_position() {
+    let (mut rx, controller, _conn, _handle) = connect_with_controller().await;
+    controller.seek(123_456).await.unwrap();
+
+    let cmd = next_client_command(&mut rx).await;
+    let ctrl = cmd.controller.expect("expected controller command");
+    assert_eq!(ctrl.command, ControllerCommandType::Seek);
+    assert_eq!(ctrl.position_ms, Some(123_456));
+    assert!(ctrl.offset_ms.is_none());
+}
+
+#[tokio::test]
+async fn test_controller_seek_relative_sends_offset() {
+    let (mut rx, controller, _conn, _handle) = connect_with_controller().await;
+    controller.seek_relative(-15_000).await.unwrap();
+
+    let cmd = next_client_command(&mut rx).await;
+    let ctrl = cmd.controller.expect("expected controller command");
+    assert_eq!(ctrl.command, ControllerCommandType::SeekRelative);
+    assert_eq!(ctrl.offset_ms, Some(-15_000));
+    assert!(ctrl.position_ms.is_none());
+}
+
 /// Start a test server that only grants specific roles, ignoring what the client requests.
 async fn start_test_server_with_roles(
     granted_roles: Vec<String>,

--- a/tests/protocol_messages.rs
+++ b/tests/protocol_messages.rs
@@ -207,6 +207,8 @@ fn test_client_command_serialization() {
             command: ControllerCommandType::Play,
             volume: None,
             mute: None,
+            position_ms: None,
+            offset_ms: None,
         }),
     };
 
@@ -275,6 +277,8 @@ fn test_client_command_volume() {
             command: ControllerCommandType::Volume,
             volume: Some(50),
             mute: None,
+            position_ms: None,
+            offset_ms: None,
         }),
     };
 
@@ -282,6 +286,126 @@ fn test_client_command_volume() {
     let json = serde_json::to_string(&message).unwrap();
 
     assert!(json.contains("\"volume\":50"));
+}
+
+#[test]
+fn test_client_command_seek() {
+    let command = ClientCommand {
+        controller: Some(ControllerCommand {
+            command: ControllerCommandType::Seek,
+            volume: None,
+            mute: None,
+            position_ms: Some(90_500),
+            offset_ms: None,
+        }),
+    };
+
+    let message = Message::ClientCommand(command);
+    let json = serde_json::to_string(&message).unwrap();
+
+    assert!(json.contains("\"command\":\"seek\""));
+    assert!(json.contains("\"position_ms\":90500"));
+    assert!(!json.contains("offset_ms"));
+
+    // Round-trip: the serialized form must deserialize back identically.
+    let parsed: Message = serde_json::from_str(&json).unwrap();
+    match parsed {
+        Message::ClientCommand(cmd) => {
+            let ctrl = cmd.controller.expect("Expected controller command");
+            assert_eq!(ctrl.command, ControllerCommandType::Seek);
+            assert_eq!(ctrl.position_ms, Some(90_500));
+            assert!(ctrl.offset_ms.is_none());
+        }
+        _ => panic!("Expected ClientCommand"),
+    }
+}
+
+#[test]
+fn test_client_command_seek_relative() {
+    let command = ClientCommand {
+        controller: Some(ControllerCommand {
+            command: ControllerCommandType::SeekRelative,
+            volume: None,
+            mute: None,
+            position_ms: None,
+            offset_ms: Some(-10_000),
+        }),
+    };
+
+    let message = Message::ClientCommand(command);
+    let json = serde_json::to_string(&message).unwrap();
+
+    assert!(json.contains("\"command\":\"seek_relative\""));
+    assert!(json.contains("\"offset_ms\":-10000"));
+    assert!(!json.contains("position_ms"));
+
+    // Round-trip: the serialized form must deserialize back identically,
+    // preserving the negative offset.
+    let parsed: Message = serde_json::from_str(&json).unwrap();
+    match parsed {
+        Message::ClientCommand(cmd) => {
+            let ctrl = cmd.controller.expect("Expected controller command");
+            assert_eq!(ctrl.command, ControllerCommandType::SeekRelative);
+            assert_eq!(ctrl.offset_ms, Some(-10_000));
+            assert!(ctrl.position_ms.is_none());
+        }
+        _ => panic!("Expected ClientCommand"),
+    }
+}
+
+#[test]
+fn test_server_state_controller_seek_max_ms() {
+    let json = r#"{
+        "type": "server/state",
+        "payload": {
+            "controller": {
+                "supported_commands": ["play", "seek", "seek_relative"],
+                "volume": 75,
+                "muted": false,
+                "seek_max_ms": 245000
+            }
+        }
+    }"#;
+
+    let message: Message = serde_json::from_str(json).unwrap();
+
+    match message {
+        Message::ServerState(state) => {
+            let controller = state.controller.expect("Expected controller");
+            assert_eq!(controller.seek_max_ms, Some(245_000));
+            assert!(controller.supported_commands.contains(&"seek".to_string()));
+            assert!(controller
+                .supported_commands
+                .contains(&"seek_relative".to_string()));
+        }
+        _ => panic!("Expected ServerState"),
+    }
+}
+
+#[test]
+fn test_server_state_controller_seek_max_ms_absent_is_none() {
+    // Servers omit seek_max_ms when the seekable range is unknown; older
+    // servers never send it. Both must deserialize to None.
+    let json = r#"{
+        "type": "server/state",
+        "payload": {
+            "controller": {
+                "supported_commands": ["play", "seek_relative"],
+                "volume": 75,
+                "muted": false
+            }
+        }
+    }"#;
+
+    let message: Message = serde_json::from_str(json).unwrap();
+
+    match message {
+        Message::ServerState(state) => {
+            let controller = state.controller.expect("Expected controller");
+            assert_eq!(controller.seek_max_ms, None);
+        }
+        _ => panic!("Expected ServerState"),
+    }
 }
 
 // =============================================================================


### PR DESCRIPTION
- Add Seek/SeekRelative variants to ControllerCommandType
- Add position_ms (seek) and offset_ms (seek_relative) fields to ControllerCommand
- Add seek_max_ms to ControllerState per updated spec
- Add Controller::seek() and Controller::seek_relative() helpers
- Wire-format round-trip, seek_max_ms-absent, and client integration tests