### PR TITLE
Add color role support

### DIFF
--- a/src/protocol/client_builder.rs
+++ b/src/protocol/client_builder.rs
@@ -31,6 +31,7 @@ pub(crate) struct ProtocolClientBuilderRaw {
     initial_player_state: Option<PlayerState>,
     metadata: bool,
     controller: bool,
+    color: bool,
 }
 
 impl From<ProtocolClientBuilderRaw> for ProtocolClientBuilder {
@@ -41,7 +42,8 @@ impl From<ProtocolClientBuilderRaw> for ProtocolClientBuilder {
             || raw.artwork_v1_support.is_some()
             || raw.visualizer_v1_support.is_some()
             || raw.metadata
-            || raw.controller;
+            || raw.controller
+            || raw.color;
 
         // Default to player@v1 if no roles were explicitly configured
         let player_v1_support = if has_explicit_role {
@@ -87,6 +89,9 @@ impl From<ProtocolClientBuilderRaw> for ProtocolClientBuilder {
         }
         if raw.controller {
             supported_roles.push("controller@v1".to_string());
+        }
+        if raw.color {
+            supported_roles.push("color@v1".to_string());
         }
 
         ProtocolClientBuilder {
@@ -137,6 +142,8 @@ pub struct ProtocolClientBuilderFields {
     metadata: bool,
     #[builder(default = false, setter(transform = || true))]
     controller: bool,
+    #[builder(default = false, setter(transform = || true))]
+    color: bool,
 }
 
 impl From<ProtocolClientBuilderFields> for ProtocolClientBuilder {
@@ -155,6 +162,7 @@ impl From<ProtocolClientBuilderFields> for ProtocolClientBuilder {
             initial_player_state: fields.initial_player_state,
             metadata: fields.metadata,
             controller: fields.controller,
+            color: fields.color,
         };
         raw.into()
     }

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -375,6 +375,51 @@ pub struct ServerState {
     /// Controller state (supported commands, volume, etc.)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub controller: Option<ControllerState>,
+    /// Color state (colors derived from the current audio)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<ColorState>,
+}
+
+/// An RGB color as `[R, G, B]` with components 0-255.
+pub type Rgb = [u8; 3];
+
+/// Color state from server (color role).
+///
+/// Colors may be extracted from album artwork, provided by the music source,
+/// or manually programmed by the server. All color fields are optional; the
+/// server sends only the palette entries it has.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ColorState {
+    /// Server clock time in microseconds for when these colors are valid
+    pub timestamp: i64,
+    /// Background color suitable for dark mode. The server ensures a minimum
+    /// WCAG contrast ratio of 4.5:1 with white text and with `on_dark`
+    /// (if also present).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub background_dark: Option<Rgb>,
+    /// Background color suitable for light mode. The server ensures a minimum
+    /// WCAG contrast ratio of 4.5:1 with black text and with `on_light`
+    /// (if also present).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub background_light: Option<Rgb>,
+    /// The dominant color. Not adjusted for contrast.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub primary: Option<Rgb>,
+    /// A secondary or complementary color. Not adjusted for contrast.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub accent: Option<Rgb>,
+    /// A light color suitable for use on dark backgrounds. The server ensures
+    /// a minimum WCAG contrast ratio of 4.5:1 with `background_dark` (if also
+    /// present) and with black text, so it can also serve as an alternative
+    /// light background.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub on_dark: Option<Rgb>,
+    /// A dark color suitable for use on light backgrounds. The server ensures
+    /// a minimum WCAG contrast ratio of 4.5:1 with `background_light` (if also
+    /// present) and with white text, so it can also serve as an alternative
+    /// dark background.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub on_light: Option<Rgb>,
 }
 
 /// Metadata state from server

--- a/tests/protocol_client.rs
+++ b/tests/protocol_client.rs
@@ -1298,6 +1298,7 @@ async fn test_message_router_forwards_text_messages() {
         sendspin::protocol::messages::ServerState {
             metadata: None,
             controller: None,
+            color: None,
         },
     ))
     .unwrap();

--- a/tests/protocol_client_builder.rs
+++ b/tests/protocol_client_builder.rs
@@ -211,3 +211,38 @@ fn test_controller_role_not_present_by_default() {
         .supported_roles()
         .contains(&"controller@v1".to_string()));
 }
+
+#[test]
+fn test_color_role_added_to_supported_roles() {
+    let builder = ProtocolClientBuilder::builder()
+        .client_id("test".to_string())
+        .name("Test Client".to_string())
+        .color()
+        .build();
+
+    assert_eq!(builder.supported_roles(), &["color@v1"]);
+    assert!(builder.player_v1_support().is_none());
+}
+
+#[test]
+fn test_color_role_not_present_by_default() {
+    let builder = ProtocolClientBuilder::builder()
+        .client_id("test".to_string())
+        .name("Test Client".to_string())
+        .build();
+
+    assert!(!builder.supported_roles().contains(&"color@v1".to_string()));
+}
+
+#[test]
+fn test_color_role_combines_with_other_roles() {
+    let builder = ProtocolClientBuilder::builder()
+        .client_id("test".to_string())
+        .name("Test Client".to_string())
+        .metadata()
+        .color()
+        .build();
+
+    assert_eq!(builder.supported_roles(), &["metadata@v1", "color@v1"]);
+    assert!(builder.player_v1_support().is_none());
+}

--- a/tests/protocol_messages.rs
+++ b/tests/protocol_messages.rs
@@ -1,11 +1,11 @@
 use sendspin::protocol::messages::{
     ArtworkChannel, ArtworkFormatRequest, ArtworkSource, ArtworkV1Support, AudioFormatSpec,
     ClientCommand, ClientGoodbye, ClientHello, ClientState, ClientSyncState, ClientTime,
-    ConnectionReason, ControllerCommand, ControllerCommandType, DeviceInfo, GoodbyeReason,
-    ImageFormat, Message, PlaybackState, PlayerCommandType, PlayerFormatRequest, PlayerState,
-    PlayerStateCommand, PlayerV1Support, RepeatMode, ServerTime, SpectrumConfig, SpectrumScale,
-    StreamArtworkChannelConfig, StreamRequestFormat, StreamVisualizerConfig, VisualizerDataType,
-    VisualizerFormatRequest, VisualizerV1Support,
+    ColorState, ConnectionReason, ControllerCommand, ControllerCommandType, DeviceInfo,
+    GoodbyeReason, ImageFormat, Message, PlaybackState, PlayerCommandType, PlayerFormatRequest,
+    PlayerState, PlayerStateCommand, PlayerV1Support, RepeatMode, ServerTime, SpectrumConfig,
+    SpectrumScale, StreamArtworkChannelConfig, StreamRequestFormat, StreamVisualizerConfig,
+    VisualizerDataType, VisualizerFormatRequest, VisualizerV1Support,
 };
 
 // =============================================================================
@@ -406,6 +406,136 @@ fn test_server_state_controller_seek_max_ms_absent_is_none() {
         }
         _ => panic!("Expected ServerState"),
     }
+}
+
+#[test]
+fn test_server_state_color_deserialization() {
+    let json = r#"{
+        "type": "server/state",
+        "payload": {
+            "color": {
+                "timestamp": 1234567890,
+                "background_dark": [18, 24, 32],
+                "background_light": [240, 244, 248],
+                "primary": [200, 60, 40],
+                "accent": [40, 120, 200],
+                "on_dark": [235, 235, 235],
+                "on_light": [30, 30, 30]
+            }
+        }
+    }"#;
+
+    let message: Message = serde_json::from_str(json).unwrap();
+
+    match message {
+        Message::ServerState(state) => {
+            let color = state.color.expect("Expected color state");
+            assert_eq!(color.timestamp, 1_234_567_890);
+            assert_eq!(color.background_dark, Some([18, 24, 32]));
+            assert_eq!(color.background_light, Some([240, 244, 248]));
+            assert_eq!(color.primary, Some([200, 60, 40]));
+            assert_eq!(color.accent, Some([40, 120, 200]));
+            assert_eq!(color.on_dark, Some([235, 235, 235]));
+            assert_eq!(color.on_light, Some([30, 30, 30]));
+        }
+        _ => panic!("Expected ServerState"),
+    }
+}
+
+#[test]
+fn test_server_state_color_sparse_fields_are_none() {
+    // The server sends only the palette entries it has; all color fields
+    // besides timestamp are optional.
+    let json = r#"{
+        "type": "server/state",
+        "payload": {
+            "color": {
+                "timestamp": 1234567890,
+                "primary": [200, 60, 40]
+            }
+        }
+    }"#;
+
+    let message: Message = serde_json::from_str(json).unwrap();
+
+    match message {
+        Message::ServerState(state) => {
+            let color = state.color.expect("Expected color state");
+            assert_eq!(color.primary, Some([200, 60, 40]));
+            assert_eq!(color.background_dark, None);
+            assert_eq!(color.background_light, None);
+            assert_eq!(color.accent, None);
+            assert_eq!(color.on_dark, None);
+            assert_eq!(color.on_light, None);
+        }
+        _ => panic!("Expected ServerState"),
+    }
+}
+
+#[test]
+fn test_server_state_color_null_clears_role_state() {
+    // A whole role object set to null clears all of that role's state; it
+    // must at minimum deserialize without error.
+    let json = r#"{
+        "type": "server/state",
+        "payload": {
+            "color": null
+        }
+    }"#;
+
+    let message: Message = serde_json::from_str(json).unwrap();
+
+    match message {
+        Message::ServerState(state) => {
+            assert!(state.color.is_none());
+        }
+        _ => panic!("Expected ServerState"),
+    }
+}
+
+#[test]
+fn test_color_state_serialization_skips_absent_fields() {
+    let color = ColorState {
+        timestamp: 42,
+        background_dark: Some([0, 0, 0]),
+        background_light: None,
+        primary: None,
+        accent: None,
+        on_dark: None,
+        on_light: None,
+    };
+
+    let json = serde_json::to_string(&color).unwrap();
+
+    assert!(json.contains("\"timestamp\":42"));
+    assert!(json.contains("\"background_dark\":[0,0,0]"));
+    assert!(!json.contains("background_light"));
+    assert!(!json.contains("primary"));
+    assert!(!json.contains("accent"));
+    assert!(!json.contains("on_dark"));
+    assert!(!json.contains("on_light"));
+}
+
+#[test]
+fn test_color_component_out_of_range_rejected() {
+    // RGB components are 0-255; 256 does not fit in a u8.
+    let json = r#"{
+        "timestamp": 42,
+        "primary": [256, 0, 0]
+    }"#;
+
+    assert!(serde_json::from_str::<ColorState>(json).is_err());
+}
+
+#[test]
+fn test_color_wrong_component_count_rejected() {
+    // Colors are exactly [R, G, B].
+    let json = r#"{
+        "timestamp": 42,
+        "primary": [10, 20]
+    }"#;
+
+    assert!(serde_json::from_str::<ColorState>(json).is_err());
 }
 
 // =============================================================================


### PR DESCRIPTION
- Add ColorState to server/state with the six spec palette entries (background_dark/light, primary, accent, on_dark/on_light) and Rgb ([u8; 3]) type alias enforcing exactly three 0-255 components
- Add color field to ServerState
- Add .color() builder flag advertising color@v1 in supported_roles
- Serde and builder tests, including component range/count rejection