### PR TITLE
fix: calculation in musl targets

### DIFF
--- a/src/sync/raw_clock.rs
+++ b/src/sync/raw_clock.rs
@@ -142,7 +142,7 @@ impl Clock for DefaultClock {
                 );
             }
         }
-        ts.tv_sec * 1_000_000 + ts.tv_nsec / 1_000
+        (ts.tv_sec * 1_000_000 + ts.tv_nsec / 1_000).into()
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/src/sync/raw_clock.rs
+++ b/src/sync/raw_clock.rs
@@ -142,6 +142,8 @@ impl Clock for DefaultClock {
                 );
             }
         }
+        // This .into() is needed on (older) musl targets
+        #[allow(clippy::useless_conversion)]
         (ts.tv_sec * 1_000_000 + ts.tv_nsec / 1_000).into()
     }
 

--- a/src/sync/raw_clock.rs
+++ b/src/sync/raw_clock.rs
@@ -144,9 +144,8 @@ impl Clock for DefaultClock {
         }
         // This cast is necessary to make builds on musl targets work
         #[allow(clippy::unnecessary_cast)]
-        (ts.tv_sec as i64)
-            * 1_000_000
-            + (ts.tv_nsec as i64) / 1_000
+        let time = (ts.tv_sec as i64) * 1_000_000 + (ts.tv_nsec as i64) / 1_000;
+        return time;
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/src/sync/raw_clock.rs
+++ b/src/sync/raw_clock.rs
@@ -144,7 +144,9 @@ impl Clock for DefaultClock {
         }
         // This cast is necessary to make builds on musl targets work
         #[allow(clippy::unnecessary_cast)]
-        (ts.tv_sec as i64) * 1_000_000 + (ts.tv_nsec as i64) / 1_000
+        (ts.tv_sec as i64)
+            * 1_000_000
+            + (ts.tv_nsec as i64) / 1_000
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/src/sync/raw_clock.rs
+++ b/src/sync/raw_clock.rs
@@ -142,9 +142,7 @@ impl Clock for DefaultClock {
                 );
             }
         }
-        // This .into() is needed on (older) musl targets
-        #[allow(clippy::useless_conversion)]
-        (ts.tv_sec * 1_000_000 + ts.tv_nsec / 1_000).into()
+        (ts.tv_sec as i64) * 1_000_000 + (ts.tv_nsec as i64) / 1_000
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/src/sync/raw_clock.rs
+++ b/src/sync/raw_clock.rs
@@ -142,6 +142,8 @@ impl Clock for DefaultClock {
                 );
             }
         }
+        // This cast is necessary to make builds on musl targets work
+        #[allow(clippy::unnecessary_cast)]
         (ts.tv_sec as i64) * 1_000_000 + (ts.tv_nsec as i64) / 1_000
     }
 


### PR DESCRIPTION
For musl targets this line is erroring (see below). So I added the conversion

```
   Compiling sendspin v0.3.5
error[E0308]: mismatched types
   --> /cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sendspin-0.3.5/src/sync/raw_clock.rs:145:9
    |
115 |     fn now_micros(&self) -> i64 {
    |                             --- expected `i64` because of return type
...
145 |         ts.tv_sec * 1_000_000 + ts.tv_nsec / 1_000
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `i64`, found `i32`
    |
help: you can convert an `i32` to an `i64`
    |
145 |         (ts.tv_sec * 1_000_000 + ts.tv_nsec / 1_000).into()
    |         +                                          ++++++++

For more information about this error, try `rustc --explain E0308`.
error: could not compile `sendspin` (lib) due to 1 previous error
```
From: https://github.com/UbiHome/UbiHome/actions/runs/29371021323/job/87214094558?pr=104