### PR TITLE
fix(clippy): use as_chunks for PCM decoding

### DIFF
--- a/src/audio/decode/pcm.rs
+++ b/src/audio/decode/pcm.rs
@@ -60,7 +60,9 @@ impl Decoder for PcmDecoder {
         match (self.bit_depth, self.endian) {
             (16, PcmEndian::Little) => {
                 let samples: Vec<i32> = data
-                    .chunks_exact(2)
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
                     .map(|c| {
                         let i16_val = i16::from_le_bytes([c[0], c[1]]);
                         i32::from_sample(i16_val)
@@ -70,7 +72,9 @@ impl Decoder for PcmDecoder {
             }
             (16, PcmEndian::Big) => {
                 let samples: Vec<i32> = data
-                    .chunks_exact(2)
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
                     .map(|c| {
                         let i16_val = i16::from_be_bytes([c[0], c[1]]);
                         i32::from_sample(i16_val)
@@ -80,7 +84,9 @@ impl Decoder for PcmDecoder {
             }
             (24, PcmEndian::Little) => {
                 let samples: Vec<i32> = data
-                    .chunks_exact(3)
+                    .as_chunks::<3>()
+                    .0
+                    .iter()
                     .map(|c| {
                         let extended = i32::from_i24_le([c[0], c[1], c[2]]);
                         i32::from_sample(cpal::I24::new_unchecked(extended))
@@ -90,7 +96,9 @@ impl Decoder for PcmDecoder {
             }
             (24, PcmEndian::Big) => {
                 let samples: Vec<i32> = data
-                    .chunks_exact(3)
+                    .as_chunks::<3>()
+                    .0
+                    .iter()
                     .map(|c| {
                         let extended = i32::from_i24_be([c[0], c[1], c[2]]);
                         i32::from_sample(cpal::I24::new_unchecked(extended))

--- a/tests/flac_conformance.rs
+++ b/tests/flac_conformance.rs
@@ -41,11 +41,15 @@ fn split_flac(bytes: &[u8]) -> (&[u8], &[u8]) {
 fn parse_expected(raw: &[u8], bits: u32) -> Vec<i32> {
     match bits {
         16 => raw
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|c| (i16::from_le_bytes([c[0], c[1]]) as i32) << 16)
             .collect(),
         24 => raw
-            .chunks_exact(3)
+            .as_chunks::<3>()
+            .0
+            .iter()
             .map(|c| {
                 // Assemble the 24-bit value in the top three bytes and use an
                 // arithmetic shift back down to sign-extend it, then widen to


### PR DESCRIPTION
Fix new clippy 1.98 findings.